### PR TITLE
feat: per-tab responses, keyboard shortcuts, and sidebar navigation

### DIFF
--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -245,7 +245,7 @@ export default function RequestPanel({ setResponse, setSentRequest, setIsLoading
         e.preventDefault();
         handleSave();
       }
-      if (e.ctrlKey && e.key === 'Enter') {
+      if ((e.ctrlKey || e.shiftKey) && e.key === 'Enter') {
         e.preventDefault();
         handleSend();
       }

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -82,7 +82,7 @@ export function useKeyboardShortcuts(additionalShortcuts?: ShortcutHandler[]) {
 // Available shortcuts for reference (used by KeyboardShortcutsModal)
 export const keyboardShortcuts = [
   { keys: 'Ctrl+S', description: 'Save current request' },
-  { keys: 'Ctrl+Enter', description: 'Send request' },
+  { keys: 'Ctrl+Enter / Shift+Enter', description: 'Send request' },
   { keys: 'Ctrl+W', description: 'Close current tab' },
   { keys: 'Ctrl+Tab', description: 'Next tab' },
   { keys: 'Ctrl+Shift+Tab', description: 'Previous tab' },

--- a/src/index.css
+++ b/src/index.css
@@ -104,6 +104,26 @@ body {
     background-color: #e9ecef;
   }
 
+  /* Sidebar focus tint */
+  .sidebar-focus-collections {
+    background-color: rgba(233, 69, 96, 0.12);
+  }
+  body.light-theme .sidebar-focus-collections {
+    background-color: rgba(201, 56, 80, 0.10);
+  }
+  .sidebar-focus-api {
+    background-color: rgba(168, 85, 247, 0.12);
+  }
+  body.light-theme .sidebar-focus-api {
+    background-color: rgba(168, 85, 247, 0.10);
+  }
+  .sidebar-focus-history {
+    background-color: rgba(59, 130, 246, 0.12);
+  }
+  body.light-theme .sidebar-focus-history {
+    background-color: rgba(59, 130, 246, 0.10);
+  }
+
   /* HTTP Method Colors - Theme Aware */
   .method-get {
     @apply bg-green-500/20 text-green-400;
@@ -529,6 +549,8 @@ body.light-theme .tooltip::after {
 .tree-item:hover {
   background-color: rgba(233, 69, 96, 0.1);
 }
+
+
 
 /* Modal backdrop */
 .modal-backdrop {


### PR DESCRIPTION
- Per-tab response data: each request tab now has its own response, sentRequest, and isLoading state. Response data is cleaned up when tabs are closed. History tabs auto-populate their response data.

- Shift+Enter to send request: power-user shortcut alongside existing Ctrl+Enter. Updated keyboard shortcuts modal to reflect both.

- Sidebar focus tint: subtle background color wash (red for collections, purple for API, blue for history) when the sidebar panel is focused. Disappears when clicking outside. Uses proper rgba() CSS classes to work with CSS variable-based theme colors.

- Auto-type to search: when the collections tab is active and the sidebar is focused, typing printable characters auto-focuses the search box and forwards keystrokes.

- Keyboard navigation in collections: Up/Down arrows navigate through the visible request list with a yellow highlight ring. Enter opens the highlighted request. Escape clears the highlight. Works both from the search input and from anywhere in the sidebar. Highlighted item auto-scrolls into view.

- Distinct active vs highlighted styles: active/open request shows red accent tint + ring; keyboard-highlighted request shows yellow tint + ring; both simultaneously shows accent tint + thick yellow ring.

Files changed:
  - src/App.tsx: per-tab TabResponseData state management
  - src/components/RequestPanel.tsx: Shift+Enter shortcut
  - src/components/Sidebar.tsx: focus tint, auto-search, keyboard nav
  - src/hooks/useKeyboardShortcuts.ts: updated shortcut labels
  - src/index.css: sidebar focus tint CSS classes