### PR TITLE
feat: in-app auto-update with post-update changelog banner

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -69,6 +69,87 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
           git push
 
+      - name: Generate changelog
+        id: changelog
+        shell: bash
+        run: |
+          NEW_TAG="${{ steps.version.outputs.tag }}"
+
+          # Find the previous release tag (most recent tag before the current commit)
+          PREV_TAG=$(git tag --sort=-v:refname | head -n 1)
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found — using full log"
+            RANGE="HEAD"
+          else
+            echo "Previous tag: $PREV_TAG"
+            RANGE="${PREV_TAG}..HEAD"
+          fi
+
+          # Collect commits, categorise them, and format for humans
+          # Categories: feat/feature, fix, refactor/chore, docs, style, test, other
+          echo "## What's New in ${NEW_TAG}" > changelog.md
+          echo "" >> changelog.md
+
+          # Features
+          FEATS=$(git log $RANGE --pretty=format:"%s" --no-merges | grep -iE "^feat(\(|:| )" || true)
+          if [ -n "$FEATS" ]; then
+            echo "### ✨ New Features" >> changelog.md
+            echo "$FEATS" | while IFS= read -r line; do
+              # Strip conventional-commit prefix for cleaner display
+              CLEAN=$(echo "$line" | sed -E 's/^feat(\([^)]*\))?[: ]*//')
+              echo "- ${CLEAN}" >> changelog.md
+            done
+            echo "" >> changelog.md
+          fi
+
+          # Fixes
+          FIXES=$(git log $RANGE --pretty=format:"%s" --no-merges | grep -iE "^fix(\(|:| )" || true)
+          if [ -n "$FIXES" ]; then
+            echo "### 🐛 Bug Fixes" >> changelog.md
+            echo "$FIXES" | while IFS= read -r line; do
+              CLEAN=$(echo "$line" | sed -E 's/^fix(\([^)]*\))?[: ]*//')
+              echo "- ${CLEAN}" >> changelog.md
+            done
+            echo "" >> changelog.md
+          fi
+
+          # Improvements (refactor, perf, style, chore)
+          IMPROVEMENTS=$(git log $RANGE --pretty=format:"%s" --no-merges | grep -iE "^(refactor|perf|style|chore|improve)(\(|:| )" | grep -viE "^chore.*bump version" || true)
+          if [ -n "$IMPROVEMENTS" ]; then
+            echo "### 🔧 Improvements" >> changelog.md
+            echo "$IMPROVEMENTS" | while IFS= read -r line; do
+              CLEAN=$(echo "$line" | sed -E 's/^(refactor|perf|style|chore|improve)(\([^)]*\))?[: ]*//')
+              echo "- ${CLEAN}" >> changelog.md
+            done
+            echo "" >> changelog.md
+          fi
+
+          # Everything else (skip version bumps and merge commits)
+          OTHERS=$(git log $RANGE --pretty=format:"%s" --no-merges \
+            | grep -viE "^(feat|fix|refactor|perf|style|chore|improve|docs|test|ci)(\(|:| )" \
+            | grep -viE "bump version|merge" || true)
+          if [ -n "$OTHERS" ]; then
+            echo "### 📦 Other Changes" >> changelog.md
+            echo "$OTHERS" | while IFS= read -r line; do
+              echo "- ${line}" >> changelog.md
+            done
+            echo "" >> changelog.md
+          fi
+
+          echo "---" >> changelog.md
+          echo "Download the installer below to update, or use **Check for Updates** inside Fetchy." >> changelog.md
+
+          echo "Changelog generated:"
+          cat changelog.md
+
+          # Store for the release body (use multiline output)
+          {
+            echo "body<<CHANGELOG_EOF"
+            cat changelog.md
+            echo "CHANGELOG_EOF"
+          } >> $GITHUB_OUTPUT
+
       - name: Build Windows installer
         run: npm run electron:build
         env:
@@ -79,14 +160,11 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Fetchy ${{ steps.version.outputs.tag }}
-          body: |
-            ## Fetchy ${{ steps.version.outputs.tag }}
-
-            ### Windows Installer
-            Download the `.exe` installer below to install Fetchy on Windows.
+          body: ${{ steps.changelog.outputs.body }}
           files: |
             release/*.exe
             release/*.exe.blockmap
+            release/latest.yml
           draft: false
           prerelease: false
         env:

--- a/electron/main.js
+++ b/electron/main.js
@@ -6,6 +6,7 @@ const https = require('https');
 const http = require('http');
 const crypto = require('crypto');
 const { execFile } = require('child_process');
+const { initUpdater } = require('./updater');
 
 /**
  * Atomic file write: writes content to a temporary file in the same directory,
@@ -199,6 +200,9 @@ function createWindow() {
   } else {
     mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
   }
+
+  // Initialise auto-updater (silent background check after launch)
+  initUpdater(mainWindow, { silentCheck: app.isPackaged });
 
   mainWindow.on('closed', () => {
     mainWindow = null;

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -61,4 +61,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return listener; // return so caller can remove it
   },
   offStorageFileChanged: (listener) => ipcRenderer.removeListener('storage-file-changed', listener),
+
+  // Auto-updater
+  updaterCheck: () => ipcRenderer.invoke('updater-check'),
+  updaterDownload: () => ipcRenderer.invoke('updater-download'),
+  updaterInstall: () => ipcRenderer.invoke('updater-install'),
+  onUpdaterEvent: (callback) => {
+    const listener = (_, data) => callback(data);
+    ipcRenderer.on('updater-event', listener);
+    return listener;
+  },
+  offUpdaterEvent: (listener) => ipcRenderer.removeListener('updater-event', listener),
+
+  // Post-update info (shown after restart)
+  getPostUpdateInfo: () => ipcRenderer.invoke('get-post-update-info'),
+  clearPostUpdateInfo: () => ipcRenderer.invoke('clear-post-update-info'),
 });

--- a/electron/updater.js
+++ b/electron/updater.js
@@ -1,0 +1,165 @@
+const { autoUpdater } = require('electron-updater');
+const { ipcMain, app } = require('electron');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Auto-updater module for Fetchy.
+ *
+ * Uses electron-updater with GitHub Releases as the update source.
+ * The main window is used to send status events to the renderer process.
+ *
+ * Events sent to renderer (channel: 'updater-event'):
+ *   { event: 'checking' }
+ *   { event: 'available',    info }
+ *   { event: 'not-available', info }
+ *   { event: 'downloading',  progress }   // progress.percent, progress.bytesPerSecond, etc.
+ *   { event: 'downloaded',   info }
+ *   { event: 'error',        error }
+ */
+
+let win = null;
+let lastUpdateInfo = null; // cache info from update-downloaded so we can persist it
+
+function sendToRenderer(data) {
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('updater-event', data);
+  }
+}
+
+/**
+ * Path to a small JSON file in userData that stores update info
+ * so the next launch can display the "what's new" banner.
+ */
+function getPostUpdateFilePath() {
+  return path.join(app.getPath('userData'), 'post-update.json');
+}
+
+function savePostUpdateInfo(info) {
+  try {
+    const data = {
+      version: info?.version ?? null,
+      releaseName: info?.releaseName ?? null,
+      releaseNotes: info?.releaseNotes ?? null,
+      releaseDate: info?.releaseDate ?? new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(getPostUpdateFilePath(), JSON.stringify(data, null, 2), 'utf-8');
+  } catch (e) {
+    console.error('Failed to save post-update info:', e);
+  }
+}
+
+// ─── Configure autoUpdater ─────────────────────────────────────────────────────
+
+autoUpdater.autoDownload = false;       // Don't download automatically – let the user decide
+autoUpdater.autoInstallOnAppQuit = true; // Install silently when the user quits
+
+// ─── autoUpdater events ────────────────────────────────────────────────────────
+
+autoUpdater.on('checking-for-update', () => {
+  sendToRenderer({ event: 'checking' });
+});
+
+autoUpdater.on('update-available', (info) => {
+  sendToRenderer({ event: 'available', info });
+});
+
+autoUpdater.on('update-not-available', (info) => {
+  sendToRenderer({ event: 'not-available', info });
+});
+
+autoUpdater.on('download-progress', (progress) => {
+  sendToRenderer({
+    event: 'downloading',
+    progress: {
+      percent: progress.percent,
+      bytesPerSecond: progress.bytesPerSecond,
+      transferred: progress.transferred,
+      total: progress.total,
+    },
+  });
+});
+
+autoUpdater.on('update-downloaded', (info) => {
+  lastUpdateInfo = info;
+  sendToRenderer({ event: 'downloaded', info });
+});
+
+autoUpdater.on('error', (err) => {
+  sendToRenderer({ event: 'error', error: err?.message || String(err) });
+});
+
+// ─── IPC handlers (renderer → main) ───────────────────────────────────────────
+
+ipcMain.handle('updater-check', async () => {
+  try {
+    const result = await autoUpdater.checkForUpdates();
+    return { success: true, version: result?.updateInfo?.version };
+  } catch (err) {
+    return { success: false, error: err?.message || String(err) };
+  }
+});
+
+ipcMain.handle('updater-download', async () => {
+  try {
+    await autoUpdater.downloadUpdate();
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err?.message || String(err) };
+  }
+});
+
+ipcMain.handle('updater-install', () => {
+  // Persist update info so we can show the banner after restart
+  if (lastUpdateInfo) {
+    savePostUpdateInfo(lastUpdateInfo);
+  }
+  // Quit the app and install the downloaded update
+  autoUpdater.quitAndInstall(false, true);
+});
+
+ipcMain.handle('get-post-update-info', () => {
+  try {
+    const filePath = getPostUpdateFilePath();
+    if (fs.existsSync(filePath)) {
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      return data;
+    }
+  } catch (e) {
+    console.error('Failed to read post-update info:', e);
+  }
+  return null;
+});
+
+ipcMain.handle('clear-post-update-info', () => {
+  try {
+    const filePath = getPostUpdateFilePath();
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+    return true;
+  } catch (e) {
+    console.error('Failed to clear post-update info:', e);
+    return false;
+  }
+});
+
+// ─── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Initialise the updater with the main BrowserWindow.
+ * Optionally performs a silent check right after launch.
+ */
+function initUpdater(mainWindow, { silentCheck = true } = {}) {
+  win = mainWindow;
+
+  if (silentCheck) {
+    // Wait a few seconds after launch so the UI has time to settle
+    setTimeout(() => {
+      autoUpdater.checkForUpdates().catch(() => { /* silent – don't bother user */ });
+    }, 5000);
+  }
+}
+
+module.exports = { initUpdater };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetchy",
-  "version": "1.5.10",
+  "version": "1.5.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fetchy",
-      "version": "1.5.10",
+      "version": "1.5.13",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.4",
@@ -21,6 +21,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.19",
         "codemirror": "^6.0.1",
+        "electron-updater": "^6.8.3",
         "immer": "^10.0.4",
         "js-yaml": "^4.1.0",
         "lucide-react": "^0.358.0",
@@ -3933,7 +3934,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -5248,6 +5248,34 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
       "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg=="
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -5783,7 +5811,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -6087,8 +6114,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
@@ -6833,7 +6859,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -6906,8 +6931,7 @@
     "node_modules/lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
-      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="
     },
     "node_modules/lcid": {
       "version": "1.0.0",
@@ -7011,6 +7035,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -9059,7 +9096,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "dev": true,
       "engines": {
         "node": ">=11.0.0"
       }
@@ -9961,6 +9997,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -10192,7 +10234,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -13509,7 +13550,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "requires": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -14513,6 +14553,28 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
       "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg=="
     },
+    "electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "requires": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.7.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+          "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+        }
+      }
+    },
     "electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -14914,7 +14976,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -15139,8 +15200,7 @@
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -15692,7 +15752,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -15756,8 +15815,7 @@
     "lazy-val": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
-      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="
     },
     "lcid": {
       "version": "1.0.0",
@@ -15835,6 +15893,16 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -17313,8 +17381,7 @@
     "sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "dev": true
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw=="
     },
     "scheduler": {
       "version": "0.23.2",
@@ -18036,6 +18103,11 @@
         }
       }
     },
+    "tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
     "tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -18210,8 +18282,7 @@
     "universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
     "update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
       "uninstallerIcon": "build/icons/win/icon.ico",
       "installerHeaderIcon": "build/icons/win/icon.ico"
     },
+    "publish": {
+      "provider": "github",
+      "owner": "AkinerAlkan94",
+      "repo": "fetchy"
+    },
     "afterPack": "./scripts/after-pack.js",
     "mac": {
       "target": "dmg",
@@ -69,6 +74,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.19",
     "codemirror": "^6.0.1",
+    "electron-updater": "^6.8.3",
     "immer": "^10.0.4",
     "js-yaml": "^4.1.0",
     "lucide-react": "^0.358.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import WorkspacesModal from './components/WorkspacesModal';
 import WorkspaceDropdown from './components/WorkspaceDropdown';
 import CreateWorkspaceScreen from './components/CreateWorkspaceScreen';
 import UpdateModal from './components/UpdateModal';
+import UpdateBanner from './components/UpdateBanner';
 import ThemeToggle from './components/ThemeToggle';
 import ResizeHandle from './components/ResizeHandle';
 import Tooltip from './components/Tooltip';
@@ -63,6 +64,35 @@ function App() {
   const [settingsInitialTab, setSettingsInitialTab] = useState<'general' | 'ai' | 'git'>('general');
   const [showWorkspacesModal, setShowWorkspacesModal] = useState(false);
   const [showUpdateModal, setShowUpdateModal] = useState(false);
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [postUpdateInfo, setPostUpdateInfo] = useState<any>(null);
+
+  // ── Post-update banner (shown once after a successful update) ─────────────
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api?.getPostUpdateInfo) return;
+    api.getPostUpdateInfo().then((info: any) => {
+      if (info) setPostUpdateInfo(info);
+    });
+  }, []);
+
+  const dismissUpdateBanner = useCallback(() => {
+    setPostUpdateInfo(null);
+    const api = (window as any).electronAPI;
+    api?.clearPostUpdateInfo?.();
+  }, []);
+
+  // ── App-update notification badge ────────────────────────────────────────
+  useEffect(() => {
+    const api = (window as any).electronAPI;
+    if (!api?.onUpdaterEvent) return;
+    const listener = api.onUpdaterEvent((data: any) => {
+      if (data.event === 'available') setUpdateAvailable(true);
+      if (data.event === 'not-available') setUpdateAvailable(false);
+      if (data.event === 'downloaded') setUpdateAvailable(true);
+    });
+    return () => api.offUpdaterEvent(listener);
+  }, []);
 
   // ── Git pull-available badge ──────────────────────────────────────────────
   const [gitPullAvailable, setGitPullAvailable] = useState(false);
@@ -351,6 +381,11 @@ function App() {
 
   return (
     <div className="h-screen w-screen flex flex-col bg-fetchy-bg overflow-hidden">
+      {/* Post-update banner */}
+      {postUpdateInfo && (
+        <UpdateBanner info={postUpdateInfo} onDismiss={dismissUpdateBanner} />
+      )}
+
       {/* Top bar */}
       <div className="h-12 bg-fetchy-sidebar border-b border-fetchy-border flex items-center px-4 justify-between shrink-0">
         <div className="flex items-center gap-3">
@@ -496,12 +531,15 @@ function App() {
 
         <ThemeToggle />
 
-        <Tooltip content="Check for Updates">
+        <Tooltip content={updateAvailable ? 'Update Available!' : 'Check for Updates'}>
           <button
             onClick={() => setShowUpdateModal(true)}
-            className="p-2 hover:bg-fetchy-border rounded text-fetchy-text-muted hover:text-fetchy-text"
+            className="relative p-2 hover:bg-fetchy-border rounded text-fetchy-text-muted hover:text-fetchy-text"
           >
             <RefreshCw size={18} />
+            {updateAvailable && (
+              <span className="absolute top-1 right-1 w-2.5 h-2.5 bg-green-500 rounded-full ring-2 ring-fetchy-bg animate-pulse" />
+            )}
           </button>
         </Tooltip>
 

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,81 @@
+import { X, Sparkles, ChevronDown, ChevronUp } from 'lucide-react';
+import { useState, useMemo } from 'react';
+
+interface PostUpdateInfo {
+  version?: string;
+  releaseName?: string;
+  releaseNotes?: string | { note: string }[] | null;
+  releaseDate?: string;
+  updatedAt?: string;
+  changelog?: string | null; // human-friendly changelog from the release
+}
+
+interface UpdateBannerProps {
+  info: PostUpdateInfo;
+  onDismiss: () => void;
+}
+
+export default function UpdateBanner({ info, onDismiss }: UpdateBannerProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const notes = useMemo(() => {
+    // Prefer the structured changelog if present
+    if (info.changelog) return info.changelog;
+    if (!info.releaseNotes) return null;
+    if (typeof info.releaseNotes === 'string') return info.releaseNotes;
+    if (Array.isArray(info.releaseNotes)) {
+      return info.releaseNotes
+        .map((n: any) => (typeof n === 'string' ? n : n.note))
+        .join('\n');
+    }
+    return null;
+  }, [info]);
+
+  return (
+    <div className="bg-gradient-to-r from-green-500/15 via-emerald-500/10 to-teal-500/15 border-b border-green-500/30 shrink-0 select-text">
+      {/* Summary row */}
+      <div className="flex items-center gap-3 px-4 py-2">
+        <Sparkles size={16} className="text-green-400 shrink-0" />
+        <span className="text-sm font-medium text-green-300">
+          Fetchy updated to {info.version ? `v${info.version.replace(/^v/, '')}` : 'a new version'}!
+        </span>
+        {info.updatedAt && (
+          <span className="text-xs text-fetchy-text-muted">
+            {new Date(info.updatedAt).toLocaleDateString()}
+          </span>
+        )}
+
+        <div className="flex-1" />
+
+        {notes && (
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="flex items-center gap-1 text-xs text-green-400 hover:text-green-300 transition-colors"
+          >
+            {expanded ? 'Hide' : 'What changed?'}
+            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </button>
+        )}
+
+        <button
+          onClick={onDismiss}
+          className="p-1 hover:bg-green-500/20 rounded text-fetchy-text-muted hover:text-fetchy-text transition-colors"
+          title="Dismiss"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {/* Expanded changelog area (read-only) */}
+      {expanded && notes && (
+        <div className="px-4 pb-3">
+          <div className="bg-fetchy-bg/60 border border-fetchy-border rounded-lg p-4 max-h-64 overflow-y-auto">
+            <pre className="text-sm text-fetchy-text whitespace-pre-wrap font-sans leading-relaxed">
+              {notes}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/UpdateModal.tsx
+++ b/src/components/UpdateModal.tsx
@@ -1,80 +1,165 @@
-import { X, Download, AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
-import { useState, useEffect } from 'react';
+import { X, Download, AlertCircle, CheckCircle, Loader2, RotateCw } from 'lucide-react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 
 interface UpdateModalProps {
   onClose: () => void;
 }
 
-interface GitHubRelease {
-  tag_name: string;
-  name: string;
-  html_url: string;
-  body: string;
-  published_at: string;
+type UpdateStatus =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'not-available'
+  | 'downloading'
+  | 'downloaded'
+  | 'error';
+
+interface DownloadProgress {
+  percent: number;
+  bytesPerSecond: number;
+  transferred: number;
+  total: number;
+}
+
+interface UpdateInfo {
+  version?: string;
+  releaseNotes?: string | { note: string }[] | null;
+  releaseName?: string;
+  releaseDate?: string;
 }
 
 const CURRENT_VERSION = __APP_VERSION__;
-const GITHUB_REPO = 'AkinerAlkan94/fetchy';
-const GITHUB_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+
+// Electron API may not be available in browser dev mode
+const api = (window as any).electronAPI;
+const isElectron = !!api?.updaterCheck;
 
 export default function UpdateModal({ onClose }: UpdateModalProps) {
-  const [isChecking, setIsChecking] = useState(true);
+  const [status, setStatus] = useState<UpdateStatus>('idle');
   const [error, setError] = useState<string | null>(null);
-  const [latestRelease, setLatestRelease] = useState<GitHubRelease | null>(null);
-  const [hasUpdate, setHasUpdate] = useState(false);
+  const [progress, setProgress] = useState<DownloadProgress | null>(null);
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+  const listenerRef = useRef<any>(null);
 
+  // Listen for updater events pushed from the main process
+  useEffect(() => {
+    if (!isElectron) return;
+
+    const listener = api.onUpdaterEvent((data: any) => {
+      switch (data.event) {
+        case 'checking':
+          setStatus('checking');
+          break;
+        case 'available':
+          setStatus('available');
+          setUpdateInfo(data.info ?? null);
+          break;
+        case 'not-available':
+          setStatus('not-available');
+          setUpdateInfo(data.info ?? null);
+          break;
+        case 'downloading':
+          setStatus('downloading');
+          setProgress(data.progress ?? null);
+          break;
+        case 'downloaded':
+          setStatus('downloaded');
+          setUpdateInfo(data.info ?? null);
+          break;
+        case 'error':
+          setStatus('error');
+          setError(data.error ?? 'Unknown error');
+          break;
+      }
+    });
+
+    listenerRef.current = listener;
+
+    return () => {
+      if (listenerRef.current) {
+        api.offUpdaterEvent(listenerRef.current);
+      }
+    };
+  }, []);
+
+  // Trigger check on mount
   useEffect(() => {
     checkForUpdates();
   }, []);
 
-  const compareVersions = (current: string, latest: string): boolean => {
-    // Remove 'v' prefix if present
-    const cleanCurrent = current.replace(/^v/, '');
-    const cleanLatest = latest.replace(/^v/, '');
-
-    const currentParts = cleanCurrent.split('.').map(Number);
-    const latestParts = cleanLatest.split('.').map(Number);
-
-    for (let i = 0; i < Math.max(currentParts.length, latestParts.length); i++) {
-      const curr = currentParts[i] || 0;
-      const lat = latestParts[i] || 0;
-
-      if (lat > curr) return true;
-      if (lat < curr) return false;
-    }
-
-    return false;
-  };
-
-  const checkForUpdates = async () => {
-    setIsChecking(true);
+  const checkForUpdates = useCallback(async () => {
+    setStatus('checking');
     setError(null);
+    setProgress(null);
+    setUpdateInfo(null);
 
-    try {
-      const response = await fetch(GITHUB_API_URL);
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch release information');
+    if (!isElectron) {
+      // Fallback for browser dev mode – use GitHub API directly
+      try {
+        const res = await fetch('https://api.github.com/repos/AkinerAlkan94/fetchy/releases/latest');
+        if (!res.ok) throw new Error('Failed to fetch release info');
+        const release = await res.json();
+        const latest = (release.tag_name ?? '').replace(/^v/, '');
+        const current = CURRENT_VERSION.replace(/^v/, '');
+        const hasUpdate = compareVersions(current, latest);
+        setUpdateInfo({
+          version: release.tag_name,
+          releaseNotes: release.body,
+          releaseName: release.name,
+          releaseDate: release.published_at,
+        });
+        setStatus(hasUpdate ? 'available' : 'not-available');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to check for updates');
+        setStatus('error');
       }
-
-      const release: GitHubRelease = await response.json();
-      setLatestRelease(release);
-
-      // Compare versions
-      const updateAvailable = compareVersions(CURRENT_VERSION, release.tag_name);
-      setHasUpdate(updateAvailable);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to check for updates');
-    } finally {
-      setIsChecking(false);
+      return;
     }
+
+    // Electron native updater
+    const result = await api.updaterCheck();
+    if (!result.success) {
+      setError(result.error ?? 'Failed to check for updates');
+      setStatus('error');
+    }
+    // Status will be updated via the updater-event listener
+  }, []);
+
+  const handleDownload = useCallback(async () => {
+    if (!isElectron) {
+      // In browser dev mode, open release page
+      window.open('https://github.com/AkinerAlkan94/fetchy/releases/latest', '_blank');
+      return;
+    }
+    setProgress({ percent: 0, bytesPerSecond: 0, transferred: 0, total: 0 });
+    setStatus('downloading');
+    const result = await api.updaterDownload();
+    if (!result.success) {
+      setError(result.error ?? 'Download failed');
+      setStatus('error');
+    }
+  }, []);
+
+  const handleInstall = useCallback(() => {
+    if (isElectron) {
+      api.updaterInstall();
+    }
+  }, []);
+
+  const formatBytes = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
-  const handleOpenReleasePage = () => {
-    if (latestRelease) {
-      window.open(latestRelease.html_url, '_blank');
+  const releaseNotes = (() => {
+    if (!updateInfo?.releaseNotes) return null;
+    if (typeof updateInfo.releaseNotes === 'string') return updateInfo.releaseNotes;
+    if (Array.isArray(updateInfo.releaseNotes)) {
+      return updateInfo.releaseNotes.map((n: any) => (typeof n === 'string' ? n : n.note)).join('\n');
     }
-  };
+    return null;
+  })();
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center modal-backdrop">
@@ -92,14 +177,16 @@ export default function UpdateModal({ onClose }: UpdateModalProps) {
 
         {/* Content */}
         <div className="p-6">
-          {isChecking && (
+          {/* Checking */}
+          {status === 'checking' && (
             <div className="flex flex-col items-center justify-center py-8">
               <Loader2 className="w-12 h-12 text-fetchy-accent animate-spin mb-4" />
               <p className="text-fetchy-text-muted">Checking for updates...</p>
             </div>
           )}
 
-          {error && !isChecking && (
+          {/* Error */}
+          {status === 'error' && (
             <div className="p-4 bg-red-500/10 border border-red-500/30 rounded-lg flex items-start gap-3 text-red-400">
               <AlertCircle size={20} className="shrink-0 mt-0.5" />
               <div>
@@ -115,41 +202,98 @@ export default function UpdateModal({ onClose }: UpdateModalProps) {
             </div>
           )}
 
-          {!isChecking && !error && hasUpdate && latestRelease && (
+          {/* Update available */}
+          {status === 'available' && updateInfo && (
             <div className="space-y-4">
               <div className="p-4 bg-green-500/10 border border-green-500/30 rounded-lg flex items-start gap-3 text-green-400">
                 <Download size={20} className="shrink-0 mt-0.5" />
                 <div className="flex-1">
                   <p className="font-medium mb-1">New version available!</p>
                   <p className="text-sm">
-                    Version {latestRelease.tag_name} is now available. You are currently using version v{CURRENT_VERSION}.
+                    Version {updateInfo.version} is ready. You are currently on v{CURRENT_VERSION}.
                   </p>
                 </div>
               </div>
 
-              <div>
-                <h3 className="font-medium text-fetchy-text mb-2">Release: {latestRelease.name}</h3>
-                <div className="text-sm text-fetchy-text-muted mb-2">
-                  Released on {new Date(latestRelease.published_at).toLocaleDateString()}
+              {releaseNotes && (
+                <div>
+                  {updateInfo.releaseName && (
+                    <h3 className="font-medium text-fetchy-text mb-2">
+                      Release: {updateInfo.releaseName}
+                    </h3>
+                  )}
+                  {updateInfo.releaseDate && (
+                    <div className="text-sm text-fetchy-text-muted mb-2">
+                      Released on {new Date(updateInfo.releaseDate).toLocaleDateString()}
+                    </div>
+                  )}
+                  <div className="bg-fetchy-bg border border-fetchy-border rounded p-4 max-h-64 overflow-y-auto">
+                    <pre className="text-sm text-fetchy-text whitespace-pre-wrap font-mono">
+                      {releaseNotes}
+                    </pre>
+                  </div>
                 </div>
-                <div className="bg-fetchy-bg border border-fetchy-border rounded p-4 max-h-64 overflow-y-auto">
-                  <pre className="text-sm text-fetchy-text whitespace-pre-wrap font-mono">
-                    {latestRelease.body || 'No release notes available.'}
-                  </pre>
-                </div>
-              </div>
+              )}
 
               <button
-                onClick={handleOpenReleasePage}
+                onClick={handleDownload}
                 className="w-full btn btn-primary flex items-center justify-center gap-2"
               >
                 <Download size={18} />
-                Download Latest Version
+                Download &amp; Install Update
               </button>
             </div>
           )}
 
-          {!isChecking && !error && !hasUpdate && latestRelease && (
+          {/* Downloading */}
+          {status === 'downloading' && progress && (
+            <div className="space-y-4">
+              <div className="flex flex-col items-center justify-center py-4">
+                <Loader2 className="w-10 h-10 text-fetchy-accent animate-spin mb-4" />
+                <p className="text-fetchy-text font-medium mb-1">Downloading update...</p>
+                <p className="text-sm text-fetchy-text-muted">
+                  {formatBytes(progress.transferred)} / {formatBytes(progress.total)}
+                  {progress.bytesPerSecond > 0 && ` — ${formatBytes(progress.bytesPerSecond)}/s`}
+                </p>
+              </div>
+              {/* Progress bar */}
+              <div className="w-full bg-fetchy-border rounded-full h-2.5 overflow-hidden">
+                <div
+                  className="bg-fetchy-accent h-2.5 rounded-full transition-all duration-300"
+                  style={{ width: `${Math.min(progress.percent, 100).toFixed(1)}%` }}
+                />
+              </div>
+              <p className="text-xs text-fetchy-text-muted text-center">
+                {progress.percent.toFixed(1)}% complete
+              </p>
+            </div>
+          )}
+
+          {/* Downloaded – ready to install */}
+          {status === 'downloaded' && (
+            <div className="space-y-4">
+              <div className="p-4 bg-green-500/10 border border-green-500/30 rounded-lg flex items-start gap-3 text-green-400">
+                <CheckCircle size={20} className="shrink-0 mt-0.5" />
+                <div>
+                  <p className="font-medium mb-1">Update downloaded!</p>
+                  <p className="text-sm">
+                    The update has been downloaded and is ready to install. Fetchy will restart to apply the update.
+                  </p>
+                </div>
+              </div>
+
+              <button
+                onClick={handleInstall}
+                className="w-full btn btn-primary flex items-center justify-center gap-2"
+              >
+                <RotateCw size={18} />
+                Restart &amp; Install
+              </button>
+            </div>
+          )}
+
+          {/* Up to date */}
+          {status === 'not-available' && (
             <div className="p-4 bg-green-500/10 border border-green-500/30 rounded-lg flex items-start gap-3 text-green-400">
               <CheckCircle size={20} className="shrink-0 mt-0.5" />
               <div>
@@ -161,11 +305,12 @@ export default function UpdateModal({ onClose }: UpdateModalProps) {
             </div>
           )}
 
-          {!isChecking && !error && (
+          {/* Version footer */}
+          {status !== 'checking' && status !== 'idle' && (
             <div className="mt-4 pt-4 border-t border-fetchy-border">
               <p className="text-xs text-fetchy-text-muted text-center">
                 Current Version: v{CURRENT_VERSION}
-                {latestRelease && ` • Latest Version: ${latestRelease.tag_name}`}
+                {updateInfo?.version && ` • Latest Version: ${updateInfo.version}`}
               </p>
             </div>
           )}
@@ -173,6 +318,12 @@ export default function UpdateModal({ onClose }: UpdateModalProps) {
 
         {/* Footer */}
         <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-fetchy-border bg-fetchy-sidebar">
+          {status !== 'checking' && status !== 'downloading' && (
+            <button onClick={checkForUpdates} className="btn btn-secondary flex items-center gap-2">
+              <RotateCw size={14} />
+              Re-check
+            </button>
+          )}
           <button onClick={onClose} className="btn btn-secondary">
             Close
           </button>
@@ -180,5 +331,15 @@ export default function UpdateModal({ onClose }: UpdateModalProps) {
       </div>
     </div>
   );
+}
+
+function compareVersions(current: string, latest: string): boolean {
+  const c = current.replace(/^v/, '').split('.').map(Number);
+  const l = latest.replace(/^v/, '').split('.').map(Number);
+  for (let i = 0; i < Math.max(c.length, l.length); i++) {
+    if ((l[i] || 0) > (c[i] || 0)) return true;
+    if ((l[i] || 0) < (c[i] || 0)) return false;
+  }
+  return false;
 }
 


### PR DESCRIPTION
- Add electron-updater for seamless in-app updates via GitHub Releases
- New electron/updater.js module: check, download, install lifecycle
- UpdateModal rewritten with download progress bar and restart button
- Passive green badge on update button when new version detected
- Post-update banner shows 'What changed?' after restart with changelog
- Persist update info to post-update.json before restart, clear on dismiss
- GitHub Actions: auto-generate categorized changelog from git commits
- Upload latest.yml to releases for electron-updater compatibility
- Expose updater + post-update IPC channels in preload.js