### PR TITLE
fix(ci): pull --rebase before pushing version bump

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -67,6 +67,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add package.json README.md
           git commit -m "chore: bump version to ${{ steps.version.outputs.new_version }}"
+          git pull --rebase origin main
           git push
 
       - name: Generate changelog


### PR DESCRIPTION
Prevents non-fast-forward rejection when remote main has advanced since the workflow checkout (e.g. from a previous run's bump commit).