### PR TITLE
fix(update): run installer silently without visible NSIS window

### DIFF
--- a/electron/updater.js
+++ b/electron/updater.js
@@ -115,8 +115,10 @@ ipcMain.handle('updater-install', () => {
   if (lastUpdateInfo) {
     savePostUpdateInfo(lastUpdateInfo);
   }
-  // Quit the app and install the downloaded update
-  autoUpdater.quitAndInstall(false, true);
+  // Quit the app and install the update silently (no NSIS installer window)
+  // isSilent = true  → no installer UI shown
+  // isForceRunAfter = true → relaunch the app after install finishes
+  autoUpdater.quitAndInstall(true, true);
 });
 
 ipcMain.handle('get-post-update-info', () => {


### PR DESCRIPTION
Pass isSilent=true to quitAndInstall so the update installs in the background without showing the Windows installer UI.