### PR TITLE
feat: transient script env vars & fix secret variable persistence

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -138,9 +138,6 @@ jobs:
             echo "" >> changelog.md
           fi
 
-          echo "---" >> changelog.md
-          echo "Download the installer below to update, or use **Check for Updates** inside Fetchy." >> changelog.md
-
           echo "Changelog generated:"
           cat changelog.md
 

--- a/src/components/EnvironmentModal.tsx
+++ b/src/components/EnvironmentModal.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef } from 'react';
-import { X, Plus, Trash2, Check, Edit2, Lock, Unlock, Download, Upload, Copy, GripVertical } from 'lucide-react';
+import { useState, useRef, useMemo } from 'react';
+import { X, Plus, Trash2, Check, Edit2, Lock, Unlock, Download, Upload, Copy, GripVertical, Zap } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -176,8 +176,8 @@ function SortableVariableRow({
     opacity: isDragging ? 0.5 : 1,
   };
 
-  const initialVal = variable.initialValue ?? variable.value ?? '';
-  const currentVal = variable.currentValue ?? '';
+  const initialVal = variable.initialValue || variable.value || '';
+  const currentVal = variable.currentValue || '';
 
   return (
     <tr ref={setNodeRef} style={style} className="border-b border-fetchy-border/50">
@@ -290,6 +290,16 @@ export default function EnvironmentModal({ onClose }: EnvironmentModalProps) {
   );
 
   const selectedEnv = environments.find(e => e.id === selectedEnvId);
+
+  // Split variables into user-defined and script-created
+  const userVariables = useMemo(
+    () => (selectedEnv?.variables ?? []).filter((v: any) => !v._fromScript),
+    [selectedEnv?.variables]
+  );
+  const scriptVariables = useMemo(
+    () => (selectedEnv?.variables ?? []).filter((v: any) => v._fromScript),
+    [selectedEnv?.variables]
+  );
 
   const handleAddEnvironment = () => {
     const env = addEnvironment('New Environment');
@@ -558,7 +568,10 @@ export default function EnvironmentModal({ onClose }: EnvironmentModalProps) {
                   <div>
                     <h3 className="font-medium text-fetchy-text">{selectedEnv.name}</h3>
                     <p className="text-xs text-fetchy-text-muted">
-                      {selectedEnv.variables.length} variable{selectedEnv.variables.length !== 1 ? 's' : ''}
+                      {userVariables.length} variable{userVariables.length !== 1 ? 's' : ''}
+                      {scriptVariables.length > 0 && (
+                        <span className="text-yellow-400/70"> + {scriptVariables.length} script</span>
+                      )}
                     </p>
                   </div>
                   <div className="flex items-center gap-2">
@@ -597,7 +610,8 @@ export default function EnvironmentModal({ onClose }: EnvironmentModalProps) {
                   </div>
                 </div>
 
-                <div className="flex-1 overflow-auto p-4">
+                <div className="flex-1 overflow-y-auto p-4">
+                  {/* ── User-defined variables ── */}
                   <DndContext
                     sensors={sensors}
                     collisionDetection={closestCenter}
@@ -617,10 +631,10 @@ export default function EnvironmentModal({ onClose }: EnvironmentModalProps) {
                       </thead>
                       <tbody>
                         <SortableContext
-                          items={selectedEnv.variables.map(v => v.id)}
+                          items={userVariables.map(v => v.id)}
                           strategy={verticalListSortingStrategy}
                         >
-                          {selectedEnv.variables.map((variable) => (
+                          {userVariables.map((variable) => (
                             <SortableVariableRow
                               key={variable.id}
                               variable={variable}
@@ -639,12 +653,67 @@ export default function EnvironmentModal({ onClose }: EnvironmentModalProps) {
                     <Plus size={14} /> Add Variable
                   </button>
 
+                  {/* ── Script-created variables (transient) ── */}
+                  {scriptVariables.length > 0 && (
+                    <div className="mt-6">
+                      <div className="flex items-center gap-2 mb-2">
+                        <Zap size={14} className="text-yellow-400" />
+                        <h4 className="text-sm font-medium text-yellow-400">Script Variables</h4>
+                        <span className="text-xs text-fetchy-text-muted">(transient – cleared on restart)</span>
+                      </div>
+                      <table className="w-full kv-table">
+                        <thead>
+                          <tr className="text-left text-xs text-fetchy-text-muted border-b border-fetchy-border">
+                            <th className="w-8 p-2"></th>
+                            <th className="p-2">Variable</th>
+                            <th className="p-2">Value</th>
+                            <th className="w-8 p-2"></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {scriptVariables.map((variable) => (
+                            <tr key={variable.id} className="border-b border-fetchy-border/50">
+                              <td className="p-2">
+                                <Zap size={12} className="text-yellow-400/60" />
+                              </td>
+                              <td className="p-0">
+                                <input
+                                  type="text"
+                                  value={variable.key}
+                                  readOnly
+                                  className="w-full bg-transparent p-2 text-sm outline-none text-fetchy-text-muted cursor-default"
+                                />
+                              </td>
+                              <td className="p-0">
+                                <input
+                                  type="text"
+                                  value={variable.currentValue ?? variable.value ?? ''}
+                                  readOnly
+                                  className="w-full bg-transparent p-2 text-sm outline-none text-yellow-400/80 cursor-default"
+                                />
+                              </td>
+                              <td className="p-2">
+                                <button
+                                  onClick={() => handleDeleteVariable(variable.id)}
+                                  className="p-1 hover:bg-fetchy-border rounded text-fetchy-text-muted hover:text-red-400"
+                                  title="Remove script variable"
+                                >
+                                  <Trash2 size={14} />
+                                </button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+
                   <div className="mt-6 p-4 bg-fetchy-sidebar rounded-lg">
                     <h4 className="text-sm font-medium text-fetchy-text mb-2">Initial vs Current Values</h4>
                     <p className="text-xs text-fetchy-text-muted mb-3">
-                      <strong className="text-fetchy-text">Initial Value:</strong> The preset/default value that can be shared and exported.
+                      <strong className="text-fetchy-text">Initial Value:</strong> The preset/default value. Persisted to disk, shared &amp; exported.
                       <br />
-                      <strong className="text-fetchy-text">Current Value:</strong> Local override value used during execution. Not exported by default.
+                      <strong className="text-fetchy-text">Current Value:</strong> Transient runtime override. <em>Cleared automatically on app restart.</em>
                     </p>
 
                     <h4 className="text-sm font-medium text-fetchy-text mb-2 mt-4">Usage</h4>
@@ -667,6 +736,17 @@ export default function EnvironmentModal({ onClose }: EnvironmentModalProps) {
                         Mark variables as secret to keep their values hidden in request history.
                         Secret values will be replaced during execution but saved as{' '}
                         <code className="text-orange-400">{'<<variableName>>'}</code> in history.
+                      </p>
+                    </div>
+
+                    <div className="mt-4 pt-4 border-t border-fetchy-border">
+                      <h4 className="text-sm font-medium text-yellow-400 mb-2 flex items-center gap-2">
+                        <Zap size={14} /> Script Variables
+                      </h4>
+                      <p className="text-xs text-fetchy-text-muted">
+                        Variables created or updated by pre/post-request scripts via{' '}
+                        <code className="text-yellow-400">fetchy.environment.set()</code>.
+                        These are transient and <em>automatically removed on app restart</em>.
                       </p>
                     </div>
                   </div>

--- a/src/store/persistence.ts
+++ b/src/store/persistence.ts
@@ -82,7 +82,8 @@ function extractSecrets(stateWrapper: any): {
         for (const variable of env.variables) {
           if (variable.isSecret) {
             const key = `env:${env.id}:${variable.id}`;
-            secretsMap[key] = variable.currentValue ?? variable.value ?? '';
+            // Use || (not ??) so empty strings fall through to the next candidate
+            secretsMap[key] = variable.currentValue || variable.value || variable.initialValue || '';
             variable.value = '';
             variable.currentValue = '';
             variable.initialValue = '';
@@ -99,7 +100,8 @@ function extractSecrets(stateWrapper: any): {
         for (const variable of col.variables) {
           if (variable.isSecret) {
             const key = `col:${col.id}:${variable.id}`;
-            secretsMap[key] = variable.currentValue ?? variable.value ?? '';
+            // Use || (not ??) so empty strings fall through to the next candidate
+            secretsMap[key] = variable.currentValue || variable.value || variable.initialValue || '';
             variable.value = '';
             variable.currentValue = '';
             variable.initialValue = '';
@@ -113,6 +115,42 @@ function extractSecrets(stateWrapper: any): {
     cleanState: { ...stateWrapper, state: cleanStateInner },
     secretsMap,
   };
+}
+
+/**
+ * Strip transient (script-set) environment variable values.
+ *
+ * - Removes variables created entirely by scripts (`_fromScript` flag)
+ * - Clears `currentValue` ONLY on variables where `_scriptOverride` is set
+ *   (i.e. the value was set by a pre/post script, not by the user in the UI)
+ * - User-set `currentValue` is preserved across restarts
+ */
+function stripTransientEnvValues(stateWrapper: any): any {
+  if (!stateWrapper?.state) return stateWrapper;
+  const state = stateWrapper.state;
+
+  if (Array.isArray(state.environments)) {
+    for (const env of state.environments) {
+      if (!Array.isArray(env.variables)) continue;
+      env.variables = env.variables
+        .filter((v: any) => {
+          // Remove variables created entirely by scripts
+          return !v._fromScript;
+        })
+        .map((v: any) => {
+          const { _fromScript, _scriptOverride, ...rest } = v;
+          if (_scriptOverride) {
+            // Script-set currentValue – clear it so it resets on restart
+            const { currentValue, ...clean } = rest;
+            return clean;
+          }
+          // User-set currentValue – keep it
+          return rest;
+        });
+    }
+  }
+
+  return stateWrapper;
 }
 
 /**
@@ -134,6 +172,7 @@ function mergeSecrets(
             const key = `env:${env.id}:${variable.id}`;
             if (secretsMap[key] !== undefined) {
               variable.value = secretsMap[key];
+              variable.initialValue = secretsMap[key];
               variable.currentValue = secretsMap[key];
             }
           }
@@ -150,6 +189,7 @@ function mergeSecrets(
             const key = `col:${col.id}:${variable.id}`;
             if (secretsMap[key] !== undefined) {
               variable.value = secretsMap[key];
+              variable.initialValue = secretsMap[key];
               variable.currentValue = secretsMap[key];
             }
           }
@@ -188,7 +228,8 @@ export const createCustomStorage = (): StateStorage => {
           } catch {
             // secrets file missing or corrupt \u2013 not fatal
           }
-
+          // 3. Strip transient (script-set) env var values
+          stateWrapper = stripTransientEnvValues(stateWrapper);
           return JSON.stringify(stateWrapper);
         } catch (error) {
           console.error('Error reading from file storage:', error);
@@ -219,7 +260,10 @@ export const createCustomStorage = (): StateStorage => {
             );
           }
 
-          // 1. Extract secrets
+          // 1. Strip transient values before writing
+          stripTransientEnvValues(stateWrapper);
+
+          // 2. Extract secrets
           const { cleanState, secretsMap } = extractSecrets(stateWrapper);
 
           // 2. Write public data (no secret values) to home directory
@@ -272,6 +316,8 @@ export const createCustomStorage = (): StateStorage => {
             stateWrapper = mergeSecrets(stateWrapper, secretsStorage.secrets);
           }
         }
+        // Strip transient (script-set) env var values
+        stateWrapper = stripTransientEnvValues(stateWrapper);
         return JSON.stringify(stateWrapper);
       } catch {
         return raw;
@@ -300,6 +346,9 @@ export const createCustomStorage = (): StateStorage => {
             }
           );
         }
+
+        // Strip transient values before writing
+        stripTransientEnvValues(stateWrapper);
 
         const { cleanState, secretsMap } = extractSecrets(stateWrapper);
         localStorage.setItem(name, JSON.stringify(cleanState));

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -393,7 +393,13 @@ const runScriptInWorker = (
   });
 };
 
-/** Apply environment variable mutations reported by the worker back to the store. */
+/**
+ * Apply environment variable mutations reported by the worker back to the store.
+ *
+ * Script-set values are written to `currentValue` so they are **transient** –
+ * they override the initial/shared value at runtime but are automatically
+ * cleared on the next app launch (see persistence.ts → stripTransientEnvValues).
+ */
 const applyEnvUpdates = (envUpdates?: Array<{ key: string; value: string }>) => {
   if (!envUpdates || envUpdates.length === 0) return;
 
@@ -405,9 +411,13 @@ const applyEnvUpdates = (envUpdates?: Array<{ key: string; value: string }>) => 
   for (const { key, value } of envUpdates) {
     const idx = variables.findIndex(v => v.key === key);
     if (idx > -1) {
-      variables[idx] = { ...variables[idx], value };
+      // Write to currentValue so the original initialValue / value are preserved
+      // Mark _scriptOverride so persistence knows to strip it on restart
+      variables[idx] = { ...variables[idx], currentValue: value, _scriptOverride: true } as any;
     } else {
-      variables.push({ id: '', key, value, enabled: true } as KeyValue);
+      // New variable created by script – only currentValue is set.
+      // On next app load it will be removed because it has no initialValue/value.
+      variables.push({ id: '', key, value: '', currentValue: value, enabled: true, _fromScript: true } as any);
     }
   }
   updateEnvironment(activeEnvironment.id, { variables });


### PR DESCRIPTION
Body:

Transient script-set environment variables
Pre/post-request scripts that set env vars via pm.environment.set() now write to [currentValue](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with a [_scriptOverride](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) flag
New script-created variables are marked with [_fromScript](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
On persist, [stripTransientEnvValues()](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) removes script-created vars and clears script-overridden [currentValue](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
User-set [currentValue](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is preserved across restarts
Fix secret variable persistence
Root cause: [extractSecrets](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) used ?? (nullish coalescing) which treats empty string '' as truthy — when a user typed in the Initial Value column, [currentValue](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) stayed as '' and was saved instead of the actual [value](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Fix: Changed to || so empty strings fall through to the next candidate
[mergeSecrets](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now also restores [initialValue](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (previously only restored [value](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [currentValue](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Display fallbacks in EnvironmentModal also changed from ?? to ||
EnvironmentModal UI improvements
Variables split into user-defined (drag-and-drop, editable) and script-created (read-only) sections
Script vars displayed with Zap icon and yellow accent
Scrollable variable list
Misc
Removed redundant "Download the installer below..." text from release changelog
Files changed
[persistence.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — [extractSecrets](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [mergeSecrets](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [stripTransientEnvValues](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[httpClient.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — [applyEnvUpdates](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with transient flags
[EnvironmentModal.tsx](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — UI split + display fix
[release-windows.yml](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — changelog cleanup