### PR TITLE
fix(tabs): preserve unsaved edits across tab switches via draftRequest

### DIFF
--- a/.github/agents/git-master.md
+++ b/.github/agents/git-master.md
@@ -1,10 +1,10 @@
 ---
 name: GitMaster
-description: Analyzes the current git diff and staged changes, generates a meaningful commit message based on the changeset, asks for the target branch, then commits and pushes. Handles merge conflicts interactively by proposing resolutions and asking for user confirmation before proceeding.
-argument-hint: Optionally provide a target branch name (e.g. "main" or "feature/my-branch"). If omitted, the agent will ask before pushing.
+description: Analyzes the current git diff and staged changes, generates a meaningful commit message, pulls latest main, commits and pushes to a new feature branch, then opens a pull request to main. Handles merge conflicts interactively by proposing resolutions and asking for user confirmation before proceeding.
+argument-hint: Optionally provide a feature branch name (e.g. "feat/my-branch", "bugfix/my-branch", "improv/my-branch" ). If omitted, the agent will suggest one based on the changes.
 ---
 
-You are GitMaster, an expert git workflow agent. Follow these steps precisely and in order:
+You are GitMaster, an expert git workflow agent. **Pushing directly to `main` is not allowed.** All changes must go through a feature branch and a pull request. Follow these steps precisely and in order:
 
 ## Step 1 — Inspect the repository state
 
@@ -16,7 +16,30 @@ Run the following commands and collect all output:
 - `git log --oneline -10` — to understand recent commit history and naming conventions used in this repo
 - `git branch --show-current` — to detect the current branch
 
-## Step 2 — Stage all changes (if nothing is staged)
+## Step 2 — Pull latest updates from main
+
+Before anything else, sync with the latest `main`:
+
+```
+git fetch origin
+git pull --rebase origin main
+```
+
+### Handling merge conflicts during pull
+
+If `git pull --rebase` reports conflicts:
+
+1. Run `git diff --diff-filter=U` to list conflicted files.
+2. For each conflicted file, read its contents and analyze both sides of the conflict markers (`<<<<<<`, `=======`, `>>>>>>>`).
+3. Propose a resolution for each conflict — explain what you kept and why.
+4. Apply the resolution by editing the file (remove all conflict markers, keep the correct merged content).
+5. Run `git add <file>` for each resolved file.
+6. Present a summary of all resolutions to the user and ask:
+   > "I've resolved the merge conflicts as described above. Does this look correct? Reply 'yes' to continue or describe any changes you'd like."
+7. Wait for user confirmation before continuing. Apply any requested adjustments.
+8. Once confirmed, run `git rebase --continue` (set `GIT_EDITOR=true` to skip the editor prompt).
+
+## Step 3 — Stage all changes (if nothing is staged)
 
 If `git diff --cached` returns no output (nothing staged), run:
 
@@ -26,7 +49,7 @@ git add -A
 
 Then re-run `git diff --cached` to confirm changes are now staged.
 
-## Step 3 — Generate a meaningful commit message
+## Step 4 — Generate a meaningful commit message
 
 Analyze the full diff carefully and produce a commit message that:
 
@@ -48,65 +71,75 @@ feat(sidebar): add collapsible panel and keyboard shortcut support
 - Persist panel width in preferencesStore
 ```
 
-## Step 4 — Ask for the target branch
+## Step 5 — Determine the feature branch name
 
-If the user provided a branch name as input, use that. Otherwise ask:
-
-> "Which branch should I push to? (current branch: `<branch>`)"
-
-Wait for the user's answer before continuing.
-
-## Step 5 — Check for divergence / merge conflicts
-
-Before committing, run:
+If the user provided a branch name as an argument, use that. Otherwise, derive a branch name from the commit message subject using the pattern:
 
 ```
-git fetch origin
-git status
+<type>/<short-kebab-case-description>
 ```
 
-If the local branch is behind the remote, run:
+Examples: `feat/sidebar-collapsible-panel`, `fix/auth-token-expiry`, `chore/update-dependencies`
+
+Present the suggested branch name to the user and ask for confirmation or edits before proceeding.
+
+> "I'll create and push to branch `<branch-name>`. Does that look good, or would you like a different name?"
+
+Wait for the user's confirmation.
+
+## Step 6 — Create the feature branch and commit
+
+If the current branch is `main` (or `master`), create a new branch. If already on a feature branch, skip branch creation.
 
 ```
-git pull --rebase origin <target-branch>
+git checkout -b <feature-branch>
 ```
 
-### Handling merge conflicts
-
-If `git pull --rebase` reports conflicts:
-
-1. Run `git diff --diff-filter=U` to list conflicted files.
-2. For each conflicted file, read its contents and analyze both sides of the conflict markers (`<<<<<<`, `=======`, `>>>>>>>`).
-3. Propose a resolution for each conflict — explain what you kept and why.
-4. Apply the resolution by editing the file (remove all conflict markers, keep the correct merged content).
-5. Run `git add <file>` for each resolved file.
-6. Present a summary of all resolutions to the user and ask:
-   > "I've resolved the merge conflicts as described above. Does this look correct? Reply 'yes' to continue or describe any changes you'd like."
-7. Wait for user confirmation before continuing. Apply any requested adjustments.
-8. Once confirmed, run `git rebase --continue` (set `GIT_EDITOR=true` to skip the editor prompt).
-
-## Step 6 — Commit
-
-Run:
+Then commit:
 
 ```
 git commit -m "<subject line>" -m "<body>"
 ```
 
-Use the commit message agreed upon in Step 3.
+Use the commit message agreed upon in Step 4.
 
-## Step 7 — Push
-
-Run:
+## Step 7 — Push the feature branch
 
 ```
-git push origin <target-branch>
+git push origin <feature-branch>
 ```
 
-Report the result to the user. If the push is rejected for any reason other than a merge conflict (e.g. protected branch, no upstream), explain the error clearly and suggest next steps.
+Report the push result to the user. If the push is rejected for any reason, show the full error output and ask the user how to proceed.
+
+## Step 8 — Open a pull request to main
+
+Use the GitHub CLI to open a pull request targeting `main`:
+
+```
+gh pr create --base main --head <feature-branch> --title "<subject line>" --body "<pr body>"
+```
+
+The PR body should include:
+- A summary of what changed and why (derived from the commit body)
+- Any relevant context or testing notes if applicable
+
+Report the PR URL to the user once created.
+
+If `gh` is not available, provide the direct GitHub URL the user can visit to open the PR manually:
+
+```
+https://github.com/<owner>/<repo>/compare/main...<feature-branch>?expand=1
+```
+
+Retrieve `<owner>/<repo>` by running:
+
+```
+git remote get-url origin
+```
 
 ## General rules
 
+- **Never push directly to `main` or `master`** — always use a feature branch + pull request.
 - Never force-push (`--force`) without explicitly being asked to by the user.
 - Always show the user the exact git commands you are about to run before running them.
 - If at any point `git` returns a non-zero exit code, stop, show the full error output, and ask the user how to proceed.

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -59,10 +59,14 @@ const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
   const isLight = isLightTheme(preferences.theme);
 
   // Mutable refs so the extensions always see the latest values without being recreated
+  const onChangeRef = useRef(onChange);
   const variableStatusesRef = useRef(variableStatuses ?? {});
   const onCursorActivityRef = useRef(onCursorActivity);
   const onKeyDownInterceptRef = useRef(onKeyDownIntercept);
+  // Flag to suppress onChange when we are programmatically syncing the editor content
+  const isSyncingRef = useRef(false);
 
+  useEffect(() => { onChangeRef.current = onChange; }, [onChange]);
   useEffect(() => { variableStatusesRef.current = variableStatuses ?? {}; }, [variableStatuses]);
   useEffect(() => { onCursorActivityRef.current = onCursorActivity; }, [onCursorActivity]);
   useEffect(() => { onKeyDownInterceptRef.current = onKeyDownIntercept; }, [onKeyDownIntercept]);
@@ -120,8 +124,8 @@ const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
         '& .cm-content ::selection': { backgroundColor: 'rgba(99, 153, 225, 0.35)' },
       })),
       EditorView.updateListener.of((update) => {
-        if (update.docChanged && !readOnly) {
-          onChange(update.state.doc.toString());
+        if (update.docChanged && !readOnly && !isSyncingRef.current) {
+          onChangeRef.current(update.state.doc.toString());
         }
         if (update.docChanged || update.selectionSet) {
           const cb = onCursorActivityRef.current;
@@ -170,11 +174,15 @@ const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
     };
   }, [language, readOnly, isLight]);
 
-  // Update content when value changes externally
+  // Update content when value changes externally (e.g. tab switch).
+  // We set isSyncingRef so the updateListener does NOT fire onChange for
+  // this programmatic content swap — otherwise the stale callback from
+  // the previous tab would be invoked before React reconciles.
   useEffect(() => {
     if (viewRef.current) {
       const currentValue = viewRef.current.state.doc.toString();
       if (currentValue !== value) {
+        isSyncingRef.current = true;
         viewRef.current.dispatch({
           changes: {
             from: 0,
@@ -182,6 +190,7 @@ const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
             insert: value,
           },
         });
+        isSyncingRef.current = false;
       }
     }
   }, [value]);

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -48,24 +48,45 @@ export default function RequestPanel({ setResponse, setSentRequest, setIsLoading
   const [showAIGenerateModal, setShowAIGenerateModal] = useState(false);
   const [curlImportFlash, setCurlImportFlash] = useState(false);
   const abortControllerRef = useRef<AbortController | null>(null);
+  // Tracks the previously-loaded tab identity so we can detect real tab switches versus
+  // incidental collection updates that should NOT overwrite unsaved edits.
+  const prevTabKeyRef = useRef<string | null>(null);
 
-  // Load request data when tab changes or when collections update
-  // BUG FIX: Added 'collections' to dependency array to prevent stale data issue
-  // Without it, when a user edits the request name in the sidebar, the local state here
-  // doesn't update. Then when saving, it would overwrite with the old name from local state.
-  // By including 'collections', the local state refreshes whenever the store updates,
-  // ensuring we always have the latest request data including name changes from sidebar.
+  // Load request data when the active tab changes or when external collection updates arrive.
+  //
+  // Rules:
+  //  1. Tab switched  → prefer tab.draftRequest (unsaved edits) if present, else load from store.
+  //  2. Same tab, not modified (e.g. sidebar rename applied)  → reload from store so the new name
+  //     is picked up (the appStore also updates draftRequest.name in this case).
+  //  3. Same tab, isModified=true → skip reload; local edits are already correct.
   useEffect(() => {
-    // If this is a history item tab, load the history request data
+    const tabKey = `${activeTab?.collectionId ?? ''}:${activeTab?.requestId ?? ''}`;
+    const tabChanged = prevTabKeyRef.current !== tabKey;
+    prevTabKeyRef.current = tabKey;
+
     if (activeTab?.isHistoryItem && activeTab?.historyRequest) {
       setLocalRequest({ ...activeTab.historyRequest });
-    } else if (activeTab?.collectionId && activeTab?.requestId) {
-      const req = getRequest(activeTab.collectionId, activeTab.requestId);
-      if (req) {
-        setLocalRequest({ ...req });
-      }
+      return;
     }
-  }, [activeTab?.requestId, activeTab?.collectionId, activeTab?.isHistoryItem, activeTab?.historyRequest, getRequest, collections]);
+
+    if (!activeTab?.collectionId || !activeTab?.requestId) return;
+
+    if (tabChanged) {
+      // Switching to a (different) tab – restore draft if the user had unsaved changes.
+      if (activeTab.draftRequest) {
+        setLocalRequest({ ...activeTab.draftRequest });
+      } else {
+        const req = getRequest(activeTab.collectionId, activeTab.requestId);
+        if (req) setLocalRequest({ ...req });
+      }
+    } else if (!activeTab.isModified) {
+      // Same tab, nothing modified – allow reload so external changes (e.g. sidebar
+      // rename, workspace sync) are reflected immediately.
+      const req = getRequest(activeTab.collectionId, activeTab.requestId);
+      if (req) setLocalRequest({ ...req });
+    }
+    // Same tab + isModified: skip reload and keep the user's unsaved edits.
+  }, [activeTab?.requestId, activeTab?.collectionId, activeTab?.isHistoryItem, activeTab?.historyRequest, activeTab?.isModified, getRequest, collections]);
 
   const handleShowCode = useCallback((language: string = 'curl') => {
     if (!request) return;
@@ -140,16 +161,24 @@ export default function RequestPanel({ setResponse, setSentRequest, setIsLoading
     } else if (activeTab?.collectionId) {
       // Normal save for regular requests
       updateRequest(activeTab.collectionId, request.id, request);
-      updateTab(activeTab.id, { isModified: false, title: request.name });
+      // Clear the draft and mark as clean.
+      updateTab(activeTab.id, { isModified: false, draftRequest: undefined, title: request.name });
     }
   }, [request, activeTab, updateRequest, updateTab, collections, addCollection, addRequest]);
 
   const handleChange = useCallback((updates: Partial<ApiRequest>) => {
     if (request) {
+      // Safety guard: skip the update if the local request is out-of-sync with the
+      // active tab (e.g. a stale closure from a CodeMirror callback fires after a
+      // rapid tab switch but before React has reconciled the new state).
+      if (activeTab?.requestId && request.id !== activeTab.requestId) return;
+
       const updated = { ...request, ...updates };
       setLocalRequest(updated);
       if (activeTab) {
-        updateTab(activeTab.id, { isModified: true });
+        // Store the full updated request as a draft so it survives tab switches and
+        // incidental collection updates without being saved to the collection.
+        updateTab(activeTab.id, { isModified: true, draftRequest: updated });
       }
     }
   }, [request, activeTab, updateTab]);
@@ -208,11 +237,6 @@ export default function RequestPanel({ setResponse, setSentRequest, setIsLoading
 
   const handleSend = useCallback(async () => {
     if (!request || isLoading) return;
-
-    // Auto-save before sending (only for requests that belong to a collection)
-    if (activeTab?.collectionId && !activeTab?.isHistoryItem) {
-      handleSave();
-    }
 
     // Create a fresh AbortController for this request
     const controller = new AbortController();

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -264,10 +264,6 @@ export default function SettingsModal({ isOpen, onClose, onOpenWorkspaces, initi
             <h3 className='text-sm font-medium text-white uppercase tracking-wider'>General Settings</h3>
             <div className='space-y-3'>
               <div className='flex items-center justify-between'>
-                <div><label className='text-sm text-gray-300'>Auto-save</label><p className='text-xs text-gray-500'>Automatically save changes to collections</p></div>
-                <input type='checkbox' checked={preferences.autoSave} onChange={(e) => savePreferences({ autoSave: e.target.checked })} className='w-4 h-4 rounded border-[#2d2d44] bg-[#0f0f1a] text-purple-500 focus:ring-purple-500' />
-              </div>
-              <div className='flex items-center justify-between'>
                 <div><label className='text-sm text-gray-300'>Max History Items</label><p className='text-xs text-gray-500'>Number of request history items to keep</p></div>
                 <input type='number' min={10} max={500} value={preferences.maxHistoryItems} onChange={(e) => savePreferences({ maxHistoryItems: parseInt(e.target.value) || 100 })} className='w-20 px-2 py-1 bg-[#0f0f1a] border border-[#2d2d44] rounded text-white text-sm focus:outline-none focus:border-purple-500' />
               </div>

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -547,11 +547,22 @@ export const useAppStore = create<AppStore>()(
             }
           }
 
-          // If the request name was updated, update any open tabs
+          // If the request name was updated, keep all open tabs in sync.
+          // • If the tab has a draftRequest (unsaved edits), update only the name field
+          //   inside the draft so the user's other modifications are not discarded.
+          // • If there is no draft, reset isModified so the panel reloads the new name
+          //   from the collection (original behaviour).
           if (updates.name) {
             state.tabs = state.tabs.map(tab => {
               if (tab.type === 'request' && tab.requestId === requestId) {
-                return { ...tab, title: updates.name!, isModified: false };
+                const draft = tab.draftRequest;
+                return {
+                  ...tab,
+                  title: updates.name!,
+                  ...(draft
+                    ? { draftRequest: { ...draft, name: updates.name! } }
+                    : { isModified: false }),
+                };
               }
               return tab;
             });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -399,6 +399,7 @@ export interface TabState {
   historyRequest?: ApiRequest; // Store the original history request data
   historyResponse?: ApiResponse; // Store the original history response data
   scriptExecutionStatus?: 'success' | 'error' | 'none'; // Flag to indicate the result of the post-request script execution
+  draftRequest?: ApiRequest; // In-memory unsaved edits — cleared on explicit save, never persisted
 }
 
 export interface AppState {

--- a/test/tab-draft-stale-state.test.ts
+++ b/test/tab-draft-stale-state.test.ts
@@ -1,0 +1,532 @@
+/**
+ * Regression tests for multi-tab unsaved edit isolation.
+ *
+ * Covers the bugs that caused field values (URL, Pre/Post-Script, body, etc.)
+ * from one focused request tab to bleed into a different tab, or for unsaved
+ * edits to be silently discarded on tab switches or incidental collection
+ * mutations (e.g. a sidebar rename).
+ *
+ * ── Bug 1 — updateRequest sidebar rename discarding unsaved edits ────────────
+ *   updateRequest({ name }) used to reset `isModified = false` unconditionally.
+ *   The RequestPanel useEffect watched `isModified` and re-read the request from
+ *   the store whenever it flipped to false, overwriting any unsaved local edits.
+ *   Fix: when the tab already carries a `draftRequest`, only sync the `name`
+ *   field inside the draft; `isModified` stays true.
+ *
+ * ── Bug 2 — handleChange accepting a stale cross-tab request ─────────────────
+ *   Asynchronous or stale closure callbacks (e.g. CodeMirror's updateListener)
+ *   could call handleChange with a request object whose id belonged to a
+ *   previously active tab, silently writing into the wrong tab's draft.
+ *   Fix: handleChange guards against request.id ≠ activeTab.requestId.
+ *
+ * ── Bug 3 — tab switch not restoring draftRequest ────────────────────────────
+ *   Switching back to a tab that had unsaved edits loaded the saved/persisted
+ *   request from the store, discarding the draft.
+ *   Fix: tab.draftRequest is preferred when switching to a modified tab.
+ *
+ * ── Bug 4 — CodeEditor stale onChange closure ────────────────────────────────
+ *   EditorView.updateListener captured onChange at mount time. After a tab
+ *   switch React reconciled a new onChange prop but the listener still held the
+ *   old one, routing new keystrokes from Tab B into Tab A's handler.
+ *   Fix: onChangeRef always holds the latest onChange; isSyncingRef suppresses
+ *   onChange during the programmatic value replacement on tab switch.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { enableMapSet, produce } from 'immer';
+import { createDefaultRequest } from '../src/store/requestTree';
+import type { ApiRequest, TabState } from '../src/types';
+
+// Mirror what appStore.ts does at module level.
+enableMapSet();
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeReq(id: string, overrides?: Partial<ApiRequest>): ApiRequest {
+  return createDefaultRequest({ id, name: `Request ${id}`, ...overrides });
+}
+
+function makeTab(overrides?: Partial<TabState>): TabState {
+  return {
+    id: 'tab-1',
+    type: 'request',
+    title: 'My Request',
+    requestId: 'r1',
+    collectionId: 'col-1',
+    isModified: false,
+    ...overrides,
+  };
+}
+
+// ─── Mirrors the name-sync mutation in appStore.ts updateRequest ──────────────
+//
+// When updateRequest is called with `updates.name`, it maps over state.tabs and
+// applies one of two strategies depending on whether the tab has a draftRequest.
+function applyNameSyncToTabs(tabs: TabState[], requestId: string, newName: string): TabState[] {
+  return produce(tabs, draft => {
+    draft.forEach(tab => {
+      if (tab.type === 'request' && tab.requestId === requestId) {
+        const dr = tab.draftRequest;
+        tab.title = newName;
+        if (dr) {
+          // Draft present → only sync name, keep isModified=true so the
+          // RequestPanel does NOT reload from the store.
+          (tab.draftRequest as ApiRequest).name = newName;
+        } else {
+          // No draft → clear isModified so the panel reloads the renamed request.
+          tab.isModified = false;
+        }
+      }
+    });
+  });
+}
+
+// ─── Mirrors the handleChange guard in RequestPanel.tsx ──────────────────────
+//
+// Applies a partial update to a request only when the request belongs to the
+// active tab, ignoring stale cross-tab callbacks.
+function safeHandleChange(
+  request: ApiRequest | null,
+  activeTabRequestId: string | undefined,
+  updates: Partial<ApiRequest>
+): ApiRequest | null {
+  if (!request) return null;
+  // Guard: skip if the local request is out-of-sync with the current tab.
+  if (activeTabRequestId && request.id !== activeTabRequestId) return null;
+  return { ...request, ...updates };
+}
+
+// ─── Mirrors the tab-switch load decision in RequestPanel.tsx useEffect ───────
+//
+// Returns what the RequestPanel would load as localRequest when the active tab
+// changes.  "store" is the persisted version of the request.
+function resolveRequestForTab(
+  tab: TabState,
+  storeRequest: ApiRequest
+): ApiRequest {
+  if (tab.draftRequest) {
+    return { ...tab.draftRequest };
+  }
+  return { ...storeRequest };
+}
+
+// ─── Bug 1 — Sidebar rename with active draft ────────────────────────────────
+
+describe('Bug 1 — updateRequest name sync: unsaved draft is preserved', () => {
+  it('updates draftRequest.name but keeps isModified=true when draft exists', () => {
+    const draft = makeReq('r1', { url: '/api/users', preScript: 'console.log("hello")' });
+    const tab = makeTab({ isModified: true, draftRequest: draft });
+
+    const [updated] = applyNameSyncToTabs([tab], 'r1', 'Renamed Request');
+
+    // Title in the tab bar should update
+    expect(updated.title).toBe('Renamed Request');
+    // Draft name should also be updated
+    expect(updated.draftRequest?.name).toBe('Renamed Request');
+    // isModified must stay true — the panel must NOT reload from the store
+    expect(updated.isModified).toBe(true);
+    // The rest of the draft (unsaved edits) must be untouched
+    expect(updated.draftRequest?.url).toBe('/api/users');
+    expect(updated.draftRequest?.preScript).toBe('console.log("hello")');
+  });
+
+  it('resets isModified=false (causing a store reload) when no draft exists', () => {
+    const tab = makeTab({ isModified: false, draftRequest: undefined });
+
+    const [updated] = applyNameSyncToTabs([tab], 'r1', 'Renamed Request');
+
+    expect(updated.title).toBe('Renamed Request');
+    expect(updated.isModified).toBe(false);
+    expect(updated.draftRequest).toBeUndefined();
+  });
+
+  it('only affects tabs whose requestId matches, leaving other tabs unchanged', () => {
+    const tabA = makeTab({ id: 'tab-a', requestId: 'r1', isModified: true, draftRequest: makeReq('r1') });
+    const tabB = makeTab({ id: 'tab-b', requestId: 'r2', isModified: false, draftRequest: undefined });
+
+    const [updA, updB] = applyNameSyncToTabs([tabA, tabB], 'r1', 'New Name');
+
+    expect(updA.title).toBe('New Name');
+    // Tab B is untouched
+    expect(updB.title).toBe('My Request');
+    expect(updB.isModified).toBe(false);
+  });
+
+  it('does not create a draftRequest if the tab had none before the rename', () => {
+    const tab = makeTab({ isModified: false });
+    const [updated] = applyNameSyncToTabs([tab], 'r1', 'Renamed');
+    expect(updated.draftRequest).toBeUndefined();
+  });
+
+  it('handles multiple tabs open on the same request id (e.g. duplicate tabs)', () => {
+    const draft = makeReq('r1', { url: '/old-url' });
+    const tab1 = makeTab({ id: 'tab-1', requestId: 'r1', isModified: true, draftRequest: draft });
+    const tab2 = makeTab({ id: 'tab-2', requestId: 'r1', isModified: false });
+
+    const [upd1, upd2] = applyNameSyncToTabs([tab1, tab2], 'r1', 'Shared Rename');
+
+    expect(upd1.title).toBe('Shared Rename');
+    expect(upd1.isModified).toBe(true); // draft preserved
+    expect(upd2.title).toBe('Shared Rename');
+    expect(upd2.isModified).toBe(false); // no draft → reload from store
+  });
+});
+
+// ─── Bug 2 — handleChange stale cross-tab request guard ──────────────────────
+
+describe('Bug 2 — handleChange: stale/cross-tab callbacks are ignored', () => {
+  it('applies updates when request.id matches the active tab', () => {
+    const req = makeReq('r1', { url: '' });
+    const result = safeHandleChange(req, 'r1', { url: '/api/new' });
+    expect(result).not.toBeNull();
+    expect(result?.url).toBe('/api/new');
+  });
+
+  it('returns null when request.id does NOT match activeTab.requestId (stale closure)', () => {
+    const staleRequest = makeReq('r1-old');
+    // Active tab is now r2 — stale CodeMirror listener fires with r1's request
+    const result = safeHandleChange(staleRequest, 'r2', { url: '/api/should-not-apply' });
+    expect(result).toBeNull();
+  });
+
+  it('allows updates when activeTabRequestId is undefined (history/unsaved tab)', () => {
+    const req = makeReq('r-temp', { url: '' });
+    const result = safeHandleChange(req, undefined, { url: '/api/history' });
+    expect(result).not.toBeNull();
+    expect(result?.url).toBe('/api/history');
+  });
+
+  it('returns null when request is null', () => {
+    expect(safeHandleChange(null, 'r1', { url: '/x' })).toBeNull();
+  });
+
+  it('does not mutate the original request object', () => {
+    const original = makeReq('r1', { url: '/original' });
+    const result = safeHandleChange(original, 'r1', { url: '/modified' });
+    expect(original.url).toBe('/original');
+    expect(result?.url).toBe('/modified');
+  });
+
+  it('merges partial updates correctly', () => {
+    const req = makeReq('r1', { url: '/base', preScript: 'old', script: 'old-post' });
+    const result = safeHandleChange(req, 'r1', { preScript: 'new-pre' });
+    expect(result?.url).toBe('/base');
+    expect(result?.preScript).toBe('new-pre');
+    expect(result?.script).toBe('old-post'); // untouched
+  });
+});
+
+// ─── Bug 3 — Tab switch must restore draftRequest ────────────────────────────
+
+describe('Bug 3 — tab switch: draftRequest is restored over the store value', () => {
+  it('returns draftRequest content when tab has unsaved edits', () => {
+    const draft = makeReq('r1', { url: '/draft-url', preScript: 'draft-script' });
+    const storeReq = makeReq('r1', { url: '/saved-url', preScript: '' });
+    const tab = makeTab({ requestId: 'r1', isModified: true, draftRequest: draft });
+
+    const resolved = resolveRequestForTab(tab, storeReq);
+
+    expect(resolved.url).toBe('/draft-url');
+    expect(resolved.preScript).toBe('draft-script');
+  });
+
+  it('returns the store value when no draft exists (clean tab)', () => {
+    const storeReq = makeReq('r1', { url: '/saved-url', script: 'saved-post' });
+    const tab = makeTab({ requestId: 'r1', isModified: false, draftRequest: undefined });
+
+    const resolved = resolveRequestForTab(tab, storeReq);
+
+    expect(resolved.url).toBe('/saved-url');
+    expect(resolved.script).toBe('saved-post');
+  });
+
+  it('draft includes all modified fields: url, preScript, script, body', () => {
+    const draft = makeReq('r1', {
+      url: '/updated',
+      method: 'POST',
+      preScript: 'pre-draft',
+      script: 'post-draft',
+      body: { type: 'json', raw: '{"key":"value"}' },
+    });
+    const storeReq = makeReq('r1', { url: '/old', method: 'GET' });
+    const tab = makeTab({ draftRequest: draft, isModified: true });
+
+    const resolved = resolveRequestForTab(tab, storeReq);
+
+    expect(resolved.url).toBe('/updated');
+    expect(resolved.method).toBe('POST');
+    expect(resolved.preScript).toBe('pre-draft');
+    expect(resolved.script).toBe('post-draft');
+    expect(resolved.body.raw).toBe('{"key":"value"}');
+  });
+
+  it('resolve returns a copy — mutating the result does not affect the draft', () => {
+    const draft = makeReq('r1', { url: '/draft' });
+    const tab = makeTab({ draftRequest: draft, isModified: true });
+    const resolved = resolveRequestForTab(tab, makeReq('r1'));
+
+    resolved.url = '/mutated';
+
+    // Original draft must be unchanged
+    expect(tab.draftRequest?.url).toBe('/draft');
+  });
+
+  it('returns store value after draft is cleared (after explicit save)', () => {
+    const storeReq = makeReq('r1', { url: '/just-saved' });
+    const tab = makeTab({ isModified: false, draftRequest: undefined });
+
+    const resolved = resolveRequestForTab(tab, storeReq);
+    expect(resolved.url).toBe('/just-saved');
+  });
+});
+
+// ─── Bug 4 — CodeEditor stale onChange closure pattern ───────────────────────
+
+describe('Bug 4 — CodeEditor: onChangeRef always dispatches to the latest callback', () => {
+  it('a ref updated after mounting reflects the new callback on the next call', () => {
+    // Simulate the pattern used in CodeEditor:
+    //   const onChangeRef = useRef(onChange);
+    //   useEffect(() => { onChangeRef.current = onChange; }, [onChange]);
+    //   listener = () => onChangeRef.current(value);
+
+    const firstHandler = vi.fn<[string], void>();
+    const secondHandler = vi.fn<[string], void>();
+
+    // Mount: ref points to firstHandler
+    const onChangeRef = { current: firstHandler };
+
+    // Simulate the listener added at mount-time
+    const listener = (value: string) => onChangeRef.current(value);
+
+    // User types on Tab A
+    listener('Tab A content');
+    expect(firstHandler).toHaveBeenCalledWith('Tab A content');
+    expect(secondHandler).not.toHaveBeenCalled();
+
+    // Tab switch: React reconciles, the useEffect updates the ref
+    onChangeRef.current = secondHandler;
+
+    // User types on Tab B — listener should now call secondHandler
+    listener('Tab B content');
+    expect(secondHandler).toHaveBeenCalledWith('Tab B content');
+    // firstHandler must NOT receive Tab B's input
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('without the ref fix — stale closure always calls the first handler (demonstrates the bug)', () => {
+    const firstHandler = vi.fn<[string], void>();
+    const secondHandler = vi.fn<[string], void>();
+
+    // Buggy version: closure captures onChange directly at mount
+    const staledListener = (value: string) => firstHandler(value); // captured, never updated
+
+    // Tab switch happens — React reconciles to secondHandler
+    // But staledListener is unaware; it still calls firstHandler
+
+    staledListener('Tab B content — routed to wrong tab!');
+    expect(firstHandler).toHaveBeenCalledWith('Tab B content — routed to wrong tab!');
+    expect(secondHandler).not.toHaveBeenCalled(); // Bug: secondHandler never gets called
+  });
+});
+
+// ─── Bug 4b — isSyncingRef suppresses spurious onChange during value sync ────
+
+describe('Bug 4b — CodeEditor: isSyncingRef suppresses onChange during programmatic value sync', () => {
+  it('onChange is NOT called when isSyncingRef is true', () => {
+    // Simulate the pattern:
+    //   isSyncingRef.current = true;
+    //   view.dispatch(changes);  — triggers updateListener internally
+    //   isSyncingRef.current = false;
+
+    const onChange = vi.fn<[string], void>();
+    const isSyncingRef = { current: false };
+
+    // Simulate the updateListener guard
+    const simulateDocChanged = (newValue: string) => {
+      if (!isSyncingRef.current) {
+        onChange(newValue);
+      }
+    };
+
+    // Normal user keystroke — should call onChange
+    simulateDocChanged('user typed');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('user typed');
+
+    // Tab switch: programmatic content replacement is wrapped in isSyncingRef
+    isSyncingRef.current = true;
+    simulateDocChanged('new tab content loaded from draft');
+    isSyncingRef.current = false;
+
+    // onChange must NOT have been called during the sync
+    expect(onChange).toHaveBeenCalledTimes(1); // still just the one from before
+
+    // After sync completes, normal keystrokes fire onChange again
+    simulateDocChanged('user typed in new tab');
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenLastCalledWith('user typed in new tab');
+  });
+
+  it('isSyncingRef resets to false even if the dispatch throws (simulated)', () => {
+    const isSyncingRef = { current: false };
+
+    // Simulate a try-finally pattern ensuring cleanup even on error
+    const safeSync = (fn: () => void) => {
+      isSyncingRef.current = true;
+      try {
+        fn();
+      } finally {
+        isSyncingRef.current = false;
+      }
+    };
+
+    safeSync(() => { /* dispatch succeeds */ });
+    expect(isSyncingRef.current).toBe(false);
+  });
+});
+
+// ─── Integration: full round-trip with multiple tabs ─────────────────────────
+
+describe('Integration — multi-tab unsaved edits survive independent tab operations', () => {
+  interface SimState {
+    tabs: TabState[];
+    storeRequests: Record<string, ApiRequest>;
+  }
+
+  function openTab(state: SimState, requestId: string, collectionId = 'col-1'): SimState {
+    const already = state.tabs.find(t => t.requestId === requestId);
+    if (already) return state;
+    return {
+      ...state,
+      tabs: [
+        ...state.tabs,
+        makeTab({ id: `tab-${requestId}`, requestId, collectionId, isModified: false }),
+      ],
+    };
+  }
+
+  function editDraft(state: SimState, tabId: string, changes: Partial<ApiRequest>): SimState {
+    return {
+      ...state,
+      tabs: state.tabs.map(t => {
+        if (t.id !== tabId) return t;
+        const base = t.draftRequest ?? state.storeRequests[t.requestId!]!;
+        const updated = { ...base, ...changes };
+        return { ...t, isModified: true, draftRequest: updated };
+      }),
+    };
+  }
+
+  function renameInSidebar(state: SimState, requestId: string, newName: string): SimState {
+    return {
+      ...state,
+      storeRequests: {
+        ...state.storeRequests,
+        [requestId]: { ...state.storeRequests[requestId], name: newName },
+      },
+      tabs: applyNameSyncToTabs(state.tabs, requestId, newName),
+    };
+  }
+
+  function getVisibleRequest(state: SimState, tabId: string): ApiRequest | null {
+    const tab = state.tabs.find(t => t.id === tabId);
+    if (!tab || !tab.requestId) return null;
+    return resolveRequestForTab(tab, state.storeRequests[tab.requestId]);
+  }
+
+  it('editing Tab A then switching to Tab B does not change Tab B content', () => {
+    let state: SimState = {
+      tabs: [],
+      storeRequests: {
+        r1: makeReq('r1', { url: '/r1', preScript: '' }),
+        r2: makeReq('r2', { url: '/r2', preScript: '' }),
+      },
+    };
+
+    state = openTab(state, 'r1');
+    state = openTab(state, 'r2');
+
+    // User edits Tab A
+    state = editDraft(state, 'tab-r1', { url: '/r1-modified', preScript: 'edited-pre' });
+
+    // Switch to Tab B — Tab B should show its own clean store content
+    const tabBContent = getVisibleRequest(state, 'tab-r2');
+    expect(tabBContent?.url).toBe('/r2');
+    expect(tabBContent?.preScript).toBe('');
+  });
+
+  it('switching back to Tab A after editing restores the unsaved draft', () => {
+    let state: SimState = {
+      tabs: [],
+      storeRequests: {
+        r1: makeReq('r1', { url: '/saved', script: '' }),
+        r2: makeReq('r2', { url: '/r2' }),
+      },
+    };
+
+    state = openTab(state, 'r1');
+    state = openTab(state, 'r2');
+
+    // User edits Tab A before switching away
+    state = editDraft(state, 'tab-r1', { url: '/unsaved', script: 'post-draft' });
+
+    // Switch to Tab B, do nothing, switch back to Tab A
+    const tabAContent = getVisibleRequest(state, 'tab-r1');
+    expect(tabAContent?.url).toBe('/unsaved');
+    expect(tabAContent?.script).toBe('post-draft');
+  });
+
+  it('sidebar rename while Tab A has draft: draft is kept, only name is updated', () => {
+    let state: SimState = {
+      tabs: [],
+      storeRequests: {
+        r1: makeReq('r1', { url: '/api/v1', preScript: 'my-script' }),
+      },
+    };
+
+    state = openTab(state, 'r1');
+    state = editDraft(state, 'tab-r1', { url: '/api/v2', preScript: 'my-script' });
+
+    // User renames the request in the sidebar while Tab A is dirty
+    state = renameInSidebar(state, 'r1', 'Renamed via sidebar');
+
+    const tabAContent = getVisibleRequest(state, 'tab-r1');
+    expect(tabAContent?.name).toBe('Renamed via sidebar'); // rename applied to draft
+    expect(tabAContent?.url).toBe('/api/v2');              // unsaved edits preserved
+    expect(tabAContent?.preScript).toBe('my-script');      // unsaved edits preserved
+
+    // Tab itself must still be marked modified
+    const tab = state.tabs.find(t => t.id === 'tab-r1')!;
+    expect(tab.isModified).toBe(true);
+  });
+
+  it('explicit save clears the draft and subsequent tab switch loads saved content', () => {
+    let state: SimState = {
+      tabs: [],
+      storeRequests: {
+        r1: makeReq('r1', { url: '/saved', script: '' }),
+      },
+    };
+
+    state = openTab(state, 'r1');
+    state = editDraft(state, 'tab-r1', { url: '/unsaved', script: 'draft' });
+
+    // Simulate explicit save: write draft to store and clear it from tab
+    const tab = state.tabs.find(t => t.id === 'tab-r1')!;
+    state = {
+      ...state,
+      storeRequests: { r1: { ...tab.draftRequest! } },
+      tabs: state.tabs.map(t =>
+        t.id === 'tab-r1' ? { ...t, isModified: false, draftRequest: undefined } : t
+      ),
+    };
+
+    const content = getVisibleRequest(state, 'tab-r1');
+    expect(content?.url).toBe('/unsaved'); // what was saved is now in the store
+    expect(content?.script).toBe('draft');
+
+    const savedTab = state.tabs.find(t => t.id === 'tab-r1')!;
+    expect(savedTab.isModified).toBe(false);
+    expect(savedTab.draftRequest).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- Add draftRequest field to TabState for in-memory unsaved edits
- RequestPanel restores draft on tab switch; reloads from store only when tab is unmodified
- Guard against stale-closure callbacks in RequestPanel#handleChange
- Fix CodeEditor stale closure: use onChangeRef + isSyncingRef to prevent programmatic sync from firing stale onChange
- Preserve draftRequest.name in appStore#updateRequest on rename
- Remove auto-save setting (draft-based save flow is now reliable)
- Add tab-draft-stale-state test suite
- Update git-master.md agent to use feature branch + PR workflow