### PR TITLE
feat(ai): refactor AI UX across request and response panels

### DIFF
--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -1,11 +1,13 @@
-import { useState, useCallback } from 'react';
-import { Bot, X, Loader2, Copy, Check, Sparkles, FileText, Terminal, MessageSquare, Bug, Download, Eye, Code2, Ticket, AlertCircle } from 'lucide-react';
+import { useState, useCallback, useEffect } from 'react';
+import { Bot, X, Loader2, Copy, Check, Sparkles, FileText, MessageSquare, Bug, Download, Eye, Code2, Ticket, AlertCircle, MessageCircle, RefreshCw } from 'lucide-react';
 import { usePreferencesStore } from '../store/preferencesStore';
 import {
   sendAIRequest,
   buildGenerateRequestPrompt,
-  buildGenerateScriptPrompt,
   buildExplainResponsePrompt,
+  buildCustomChatPrompt,
+  buildConvertToFetchySyntaxPrompt,
+  buildScriptChatPrompt,
   buildGenerateDocsPrompt,
   buildGenerateBugReportPrompt,
   PROVIDER_META,
@@ -175,22 +177,26 @@ interface AIResultModalProps {
   error: string;
   result: string;
   onCopy?: () => void;
-  onApply?: () => void;
+  onApply?: (content: string) => void;
   applyLabel?: string;
   language?: string;
   isMarkdown?: boolean;
   downloadFileName?: string;
+  allowEdit?: boolean;
   onCreateJira?: () => void;
   jiraLoading?: boolean;
   jiraResult?: { success: boolean; issueKey?: string; issueUrl?: string; error?: string } | null;
 }
 
-function AIResultModal({ isOpen, onClose, title, icon, loading, error, result, onCopy, onApply, applyLabel, language, isMarkdown, downloadFileName, onCreateJira, jiraLoading, jiraResult }: AIResultModalProps) {
+function AIResultModal({ isOpen, onClose, title, icon, loading, error, result, onCopy, onApply, applyLabel, language, isMarkdown, allowEdit, downloadFileName, onCreateJira, jiraLoading, jiraResult }: AIResultModalProps) {
   const [copied, setCopied] = useState(false);
   const [mdView, setMdView] = useState<'preview' | 'source'>('preview');
+  const [editedContent, setEditedContent] = useState(result);
+
+  useEffect(() => { setEditedContent(result); }, [result]);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(result);
+    navigator.clipboard.writeText(editedContent);
     setCopied(true);
     onCopy?.();
     setTimeout(() => setCopied(false), 2000);
@@ -277,7 +283,12 @@ function AIResultModal({ isOpen, onClose, title, icon, loading, error, result, o
                   )
                 ) : language ? (
                   <div className='h-[400px]'>
-                    <CodeEditor value={result} onChange={() => {}} language={language as 'json' | 'javascript' | 'text'} readOnly />
+                    <CodeEditor
+                      value={editedContent}
+                      onChange={allowEdit ? setEditedContent : () => {}}
+                      language={language as 'json' | 'javascript' | 'text'}
+                      readOnly={!allowEdit}
+                    />
                   </div>
                 ) : (
                   <div className='prose prose-invert prose-sm max-w-none text-gray-300 ai-markdown-content p-4 overflow-auto h-full'>
@@ -306,7 +317,7 @@ function AIResultModal({ isOpen, onClose, title, icon, loading, error, result, o
                 )}
                 {onApply && (
                   <button
-                    onClick={onApply}
+                    onClick={() => onApply(editedContent)}
                     className='px-3 py-1.5 text-sm ai-btn-solid rounded transition-colors flex items-center gap-1.5'
                   >
                     <Check size={14} />
@@ -498,88 +509,186 @@ function AIActionButton({ icon, label, onClick, loading, disabled }: AIActionBut
   );
 }
 
-// ─── AI Toolbar for Request Panel ───────────────────────────────────────────
+// ─── AI Script Assist Button (for Pre-Script / Post-Script tabs) ────────────
 
-interface AIRequestToolbarProps {
-  request: ApiRequest;
-  response?: ApiResponse | null;
-  onOpenGenerateRequest: () => void;
-  onApplyScript: (script: string, type: 'pre-request' | 'test') => void;
-  onApplyName?: (name: string) => void;
+interface AIScriptAssistButtonProps {
+  scriptType: 'pre' | 'post';
+  scriptValue: string;
+  onApply: (code: string) => void;
 }
 
-export function AIRequestToolbar({
-  request,
-  response,
-  onOpenGenerateRequest,
-  onApplyScript,
-}: AIRequestToolbarProps) {
+export function AIScriptAssistButton({ scriptType, scriptValue, onApply }: AIScriptAssistButtonProps) {
   const { aiSettings: ai } = usePreferencesStore();
 
-  const [scriptModal, setScriptModal] = useState<{
-    open: boolean;
-    type: 'pre-request' | 'test';
-    loading: boolean;
-    error: string;
-    result: string;
-  }>({ open: false, type: 'pre-request', loading: false, error: '', result: '' });
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [selectedMode, setSelectedMode] = useState<'convert' | 'chat' | null>(null);
+  const [chatMessage, setChatMessage] = useState('');
 
-  const handleGenerateScript = useCallback(
-    async (type: 'pre-request' | 'test') => {
-      // If not configured, open AI settings instead of showing error modal
-      if (!ai.apiKey && !ai.baseUrl) {
-        window.dispatchEvent(new CustomEvent('open-ai-settings'));
-        return;
-      }
-      setScriptModal({ open: true, type, loading: true, error: '', result: '' });
-      const messages = buildGenerateScriptPrompt(request, response ?? undefined, type);
-      const res = await sendAIRequest(ai, messages);
-      if (res.success) {
-        // Clean markdown fences
-        let cleaned = res.content.trim();
-        if (cleaned.startsWith('```')) {
-          cleaned = cleaned.replace(/^```(?:javascript|js)?\n?/, '').replace(/\n?```$/, '');
+  const [result, setResult] = useState<{ loading: boolean; error: string; content: string; mode: 'convert' | 'chat' | null }>({
+    loading: false, error: '', content: '', mode: null,
+  });
+
+  const handleAsk = useCallback(async () => {
+    if (!selectedMode) return;
+    if (!ai.apiKey && !ai.baseUrl) {
+      window.dispatchEvent(new CustomEvent('open-ai-settings'));
+      return;
+    }
+
+    setPanelOpen(false);
+    const mode = selectedMode;
+    const msg = chatMessage.trim();
+    setChatMessage('');
+    setSelectedMode(null);
+    setResult({ loading: true, error: '', content: '', mode });
+
+    const messages =
+      mode === 'convert'
+        ? buildConvertToFetchySyntaxPrompt(scriptValue, scriptType)
+        : buildScriptChatPrompt(scriptValue, scriptType, msg || 'Help me improve this script.');
+
+    const res = await sendAIRequest(ai, messages);
+    if (res.success) {
+      let content = res.content.trim();
+      if (mode === 'convert') {
+        // Strip markdown fences if the model adds them
+        if (content.startsWith('```')) {
+          content = content.replace(/^```(?:javascript|js)?\n?/, '').replace(/\n?```$/, '');
         }
-        setScriptModal((prev) => ({ ...prev, loading: false, result: cleaned }));
-      } else {
-        setScriptModal((prev) => ({ ...prev, loading: false, error: res.error || 'Failed to generate script' }));
       }
-    },
-    [request, response, ai]
-  );
+      setResult({ loading: false, error: '', content, mode });
+    } else {
+      setResult({ loading: false, error: res.error || 'AI request failed', content: '', mode });
+    }
+  }, [selectedMode, chatMessage, scriptValue, scriptType, ai]);
 
   if (!ai.enabled) return null;
 
+  const modes = [
+    {
+      id: 'convert' as const,
+      icon: <RefreshCw size={14} />,
+      label: 'Convert to Fetchy Syntax',
+      description: 'Rewrite the current script using the Fetchy scripting API',
+    },
+    {
+      id: 'chat' as const,
+      icon: <MessageCircle size={14} />,
+      label: 'Custom Chat',
+      description: 'Ask anything — current script code is included in context automatically',
+    },
+  ];
+
   return (
     <>
-      <div className='flex items-center gap-1.5 flex-wrap'>
-        <span className='text-[10px] ai-text font-medium uppercase tracking-wider flex items-center gap-1'>
-          <Bot size={10} /> AI
-        </span>
-        <AIActionButton icon={<Sparkles size={12} />} label='Generate Request' onClick={() => {
+      <button
+        onClick={() => {
           if (!ai.apiKey && !ai.baseUrl) { window.dispatchEvent(new CustomEvent('open-ai-settings')); return; }
-          onOpenGenerateRequest();
-        }} />
-        <AIActionButton icon={<Terminal size={12} />} label='Pre-Script' onClick={() => handleGenerateScript('pre-request')} />
-        {/* 'test' is the internal script type key — label is intentionally "Post-Script", do not rename */}
-        <AIActionButton icon={<Terminal size={12} />} label='Post-Script' onClick={() => handleGenerateScript('test')} />
-      </div>
-
-      <AIResultModal
-        isOpen={scriptModal.open}
-        onClose={() => setScriptModal((prev) => ({ ...prev, open: false }))}
-        title={`AI Generated ${scriptModal.type === 'pre-request' ? 'Pre-Request' : 'Post-Request'} Script`}
-        icon={<Terminal size={18} className='ai-text' />}
-        loading={scriptModal.loading}
-        error={scriptModal.error}
-        result={scriptModal.result}
-        language='javascript'
-        onApply={() => {
-          onApplyScript(scriptModal.result, scriptModal.type);
-          setScriptModal((prev) => ({ ...prev, open: false }));
+          setPanelOpen(true);
         }}
-        applyLabel={`Apply to ${scriptModal.type === 'pre-request' ? 'Pre-Script' : 'Post-Script'}`}
-      />
+        className='w-full flex items-center justify-center gap-1.5 px-2.5 py-1.5 text-xs ai-btn-solid rounded transition-colors'
+        title='AI Assist'
+      >
+        <Bot size={12} />
+        <span>AI Assist</span>
+      </button>
+
+      {/* Selection panel */}
+      {panelOpen && (
+        <div className='fixed inset-0 bg-black/50 flex items-center justify-center z-50'>
+          <div className='bg-fetchy-modal rounded-lg shadow-xl w-[480px] overflow-hidden border border-fetchy-border'>
+            <div className='flex items-center justify-between p-4 border-b border-[#2d2d44]'>
+              <div className='flex items-center gap-2'>
+                <Bot size={18} className='ai-text' />
+                <h2 className='text-lg font-semibold text-white'>AI Assist — {scriptType === 'pre' ? 'Pre-Script' : 'Post-Script'}</h2>
+              </div>
+              <button
+                onClick={() => { setPanelOpen(false); setSelectedMode(null); setChatMessage(''); }}
+                className='p-1 text-gray-400 hover:text-white hover:bg-[#2d2d44] rounded'
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <div className='p-4 space-y-3'>
+              <p className='text-xs text-gray-500 uppercase tracking-wider font-medium'>Select an action</p>
+              <div className='space-y-2'>
+                {modes.map((mode) => (
+                  <button
+                    key={mode.id}
+                    onClick={() => setSelectedMode(mode.id)}
+                    className={`w-full text-left px-3 py-2.5 rounded border transition-colors ${
+                      selectedMode === mode.id
+                        ? 'border-fetchy-accent bg-fetchy-accent/10'
+                        : 'border-[#2d2d44] bg-[#0f0f1a] hover:border-fetchy-accent/50 hover:bg-[#1a1a2e]'
+                    }`}
+                  >
+                    <div className='flex items-center gap-2 ai-text'>
+                      {mode.icon}
+                      <span className='text-sm font-medium text-white'>{mode.label}</span>
+                    </div>
+                    <p className='text-xs text-gray-500 mt-0.5 ml-[22px]'>{mode.description}</p>
+                  </button>
+                ))}
+              </div>
+              {selectedMode === 'chat' && (
+                <div className='space-y-2 pt-1'>
+                  <label className='text-sm text-gray-300 font-medium'>Your message</label>
+                  <textarea
+                    value={chatMessage}
+                    onChange={(e) => setChatMessage(e.target.value)}
+                    placeholder='e.g. "How do I extract the token from the response and save it?"'
+                    rows={4}
+                    className='w-full px-3 py-2 bg-[#0f0f1a] border border-[#2d2d44] rounded text-white text-sm resize-none focus:outline-none ai-focus'
+                    autoFocus
+                  />
+                  <p className='text-xs text-gray-500'>The current script code is automatically included in context.</p>
+                </div>
+              )}
+              <div className='flex gap-2 justify-end pt-1'>
+                <button
+                  onClick={() => { setPanelOpen(false); setSelectedMode(null); setChatMessage(''); }}
+                  className='px-4 py-2 text-sm bg-[#0f0f1a] text-gray-300 border border-[#2d2d44] rounded hover:bg-[#1a1a2e] transition-colors'
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleAsk}
+                  disabled={!selectedMode || (selectedMode === 'chat' && !chatMessage.trim())}
+                  className='px-4 py-2 text-sm ai-btn-solid rounded transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed'
+                >
+                  <Sparkles size={14} />
+                  Ask
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Result modal */}
+      {(result.loading || result.content || result.error) && (
+        <AIResultModal
+          isOpen={true}
+          onClose={() => setResult({ loading: false, error: '', content: '', mode: null })}
+          title={result.mode === 'convert' ? 'Convert to Fetchy Syntax' : 'AI Script Chat'}
+          icon={result.mode === 'convert' ? <RefreshCw size={18} className='ai-text' /> : <MessageCircle size={18} className='ai-text' />}
+          loading={result.loading}
+          error={result.error}
+          result={result.content}
+          language={result.mode === 'convert' ? 'javascript' : undefined}
+          isMarkdown={result.mode === 'chat'}
+          allowEdit={result.mode === 'convert'}
+          onApply={
+            result.mode === 'convert' && result.content
+              ? (content) => {
+                  onApply(content);
+                  setResult({ loading: false, error: '', content: '', mode: null });
+                }
+              : undefined
+          }
+          applyLabel='Apply to Script'
+        />
+      )}
     </>
   );
 }
@@ -594,68 +703,52 @@ interface AIResponseToolbarProps {
 export function AIResponseToolbar({ request, response }: AIResponseToolbarProps) {
   const { aiSettings: ai, jiraSettings, jiraPat } = usePreferencesStore();
 
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [selectedSnippet, setSelectedSnippet] = useState<'explain' | 'docs' | 'bugreport' | 'customchat' | null>(null);
+  const [bugNote, setBugNote] = useState('');
+  const [customChatMessage, setCustomChatMessage] = useState('');
+
   const [modal, setModal] = useState<{
     open: boolean;
-    feature: 'explain' | 'docs' | 'bugreport';
+    feature: 'explain' | 'docs' | 'bugreport' | 'customchat';
     loading: boolean;
     error: string;
     result: string;
   }>({ open: false, feature: 'explain', loading: false, error: '', result: '' });
 
-  const [bugReportPrompt, setBugReportPrompt] = useState(false);
-  const [bugNote, setBugNote] = useState('');
   const [jiraLoading, setJiraLoading] = useState(false);
   const [jiraResult, setJiraResult] = useState<{ success: boolean; issueKey?: string; issueUrl?: string; error?: string } | null>(null);
 
-  const handleExplain = useCallback(async () => {
-    // If not configured, open AI settings instead of showing error modal
+  const handleAsk = useCallback(async () => {
+    if (!selectedSnippet) return;
     if (!ai.apiKey && !ai.baseUrl) {
       window.dispatchEvent(new CustomEvent('open-ai-settings'));
       return;
     }
-    setModal({ open: true, feature: 'explain', loading: true, error: '', result: '' });
-    const messages = buildExplainResponsePrompt(request, response);
-    const res = await sendAIRequest(ai, messages);
-    if (res.success) {
-      setModal((prev) => ({ ...prev, loading: false, result: res.content }));
-    } else {
-      setModal((prev) => ({ ...prev, loading: false, error: res.error || 'Failed to explain response' }));
-    }
-  }, [request, response, ai]);
+    setPanelOpen(false);
+    setModal({ open: true, feature: selectedSnippet, loading: true, error: '', result: '' });
 
-  const handleGenerateDocs = useCallback(async () => {
-    // If not configured, open AI settings instead of showing error modal
-    if (!ai.apiKey && !ai.baseUrl) {
-      window.dispatchEvent(new CustomEvent('open-ai-settings'));
-      return;
-    }
-    setModal({ open: true, feature: 'docs', loading: true, error: '', result: '' });
-    const messages = buildGenerateDocsPrompt(request, response);
-    const res = await sendAIRequest(ai, messages);
-    if (res.success) {
-      setModal((prev) => ({ ...prev, loading: false, result: res.content }));
+    let messages;
+    if (selectedSnippet === 'explain') {
+      messages = buildExplainResponsePrompt(request, response);
+    } else if (selectedSnippet === 'docs') {
+      messages = buildGenerateDocsPrompt(request, response);
+    } else if (selectedSnippet === 'customchat') {
+      messages = buildCustomChatPrompt(request, response, customChatMessage.trim() || 'Analyze this request and response.');
     } else {
-      setModal((prev) => ({ ...prev, loading: false, error: res.error || 'Failed to generate docs' }));
+      messages = buildGenerateBugReportPrompt(request, response, bugNote || 'The response is not in the expected format.');
     }
-  }, [request, response, ai]);
-
-  const handleGenerateBugReport = useCallback(async (note: string) => {
-    // If not configured, open AI settings instead of showing error modal
-    if (!ai.apiKey && !ai.baseUrl) {
-      window.dispatchEvent(new CustomEvent('open-ai-settings'));
-      return;
-    }
-    setBugReportPrompt(false);
     setBugNote('');
-    setModal({ open: true, feature: 'bugreport', loading: true, error: '', result: '' });
-    const messages = buildGenerateBugReportPrompt(request, response, note);
+    setCustomChatMessage('');
+    setSelectedSnippet(null);
+
     const res = await sendAIRequest(ai, messages);
     if (res.success) {
       setModal((prev) => ({ ...prev, loading: false, result: res.content }));
     } else {
-      setModal((prev) => ({ ...prev, loading: false, error: res.error || 'Failed to generate bug report' }));
+      setModal((prev) => ({ ...prev, loading: false, error: res.error || 'Failed to get AI response' }));
     }
-  }, [request, response, ai]);
+  }, [selectedSnippet, bugNote, request, response, ai]);
 
   const jiraConfigured = jiraSettings.enabled && jiraSettings.baseUrl && jiraPat && jiraSettings.projectKey;
 
@@ -776,13 +869,22 @@ export function AIResponseToolbar({ request, response }: AIResponseToolbarProps)
     explain: 'AI Response Explanation',
     docs: 'AI Generated Documentation',
     bugreport: 'AI Generated Bug Report',
+    customchat: 'AI Custom Chat',
   };
 
   const modalIcons: Record<string, React.ReactNode> = {
     explain: <MessageSquare size={18} className='ai-text' />,
     docs: <FileText size={18} className='ai-text' />,
     bugreport: <Bug size={18} className='ai-text' />,
+    customchat: <MessageCircle size={18} className='ai-text' />,
   };
+
+  const snippets = [
+    { id: 'explain' as const, icon: <MessageSquare size={14} />, label: 'Explain Response', description: 'Get a clear explanation of what this response means' },
+    { id: 'docs' as const, icon: <FileText size={14} />, label: 'Generate Docs', description: 'Generate API documentation for this endpoint' },
+    { id: 'bugreport' as const, icon: <Bug size={14} />, label: 'Bug Report', description: 'Create a structured bug report from this response' },
+    { id: 'customchat' as const, icon: <MessageCircle size={14} />, label: 'Custom Chat', description: 'Ask anything — full request & response context is included automatically' },
+  ];
 
   return (
     <>
@@ -790,61 +892,94 @@ export function AIResponseToolbar({ request, response }: AIResponseToolbarProps)
         <span className='text-[10px] ai-text font-medium uppercase tracking-wider flex items-center gap-1'>
           <Bot size={10} /> AI
         </span>
-        <AIActionButton icon={<MessageSquare size={12} />} label='Explain Response' onClick={handleExplain} />
-        <AIActionButton icon={<FileText size={12} />} label='Generate Docs' onClick={handleGenerateDocs} />
-        <AIActionButton icon={<Bug size={12} />} label='Bug Report' onClick={() => {
-          if (!ai.apiKey && !ai.baseUrl) { window.dispatchEvent(new CustomEvent('open-ai-settings')); return; }
-          setBugReportPrompt(true);
-        }} />
+        <AIActionButton
+          icon={<Sparkles size={12} />}
+          label='AI Assist'
+          onClick={() => {
+            if (!ai.apiKey && !ai.baseUrl) { window.dispatchEvent(new CustomEvent('open-ai-settings')); return; }
+            setPanelOpen(true);
+          }}
+        />
         <span className='text-[10px] text-gray-500 ml-1'>via {providerLabel}</span>
       </div>
 
-      {/* Bug Report Note Prompt */}
-      {bugReportPrompt && (
+      {/* AI Assist Panel */}
+      {panelOpen && (
         <div className='fixed inset-0 bg-black/50 flex items-center justify-center z-50'>
-          <div className='bg-fetchy-modal rounded-lg shadow-xl w-[500px] overflow-hidden border border-fetchy-border'>
+          <div className='bg-fetchy-modal rounded-lg shadow-xl w-[480px] overflow-hidden border border-fetchy-border'>
             <div className='flex items-center justify-between p-4 border-b border-[#2d2d44]'>
               <div className='flex items-center gap-2'>
-                <Bug size={18} className='ai-text' />
-                <h2 className='text-lg font-semibold text-white'>Generate Bug Report</h2>
+                <Bot size={18} className='ai-text' />
+                <h2 className='text-lg font-semibold text-white'>AI Assist</h2>
               </div>
               <button
-                onClick={() => { setBugReportPrompt(false); setBugNote(''); }}
+                onClick={() => { setPanelOpen(false); setSelectedSnippet(null); setBugNote(''); }}
                 className='p-1 text-gray-400 hover:text-white hover:bg-[#2d2d44] rounded'
               >
                 <X size={18} />
               </button>
             </div>
-            <div className='p-4 space-y-4'>
+            <div className='p-4 space-y-3'>
+              <p className='text-xs text-gray-500 uppercase tracking-wider font-medium'>Select an action</p>
               <div className='space-y-2'>
-                <label className='text-sm text-gray-300 font-medium'>
-                  What did you expect from this response?
-                </label>
-                <textarea
-                  value={bugNote}
-                  onChange={(e) => setBugNote(e.target.value)}
-                  placeholder='e.g., "Expected status 200 with a list of users, but got 500" or "Response body is missing the email field" or "Status is 403 but I sent valid auth token"'
-                  rows={4}
-                  className='w-full px-3 py-2 bg-[#0f0f1a] border border-[#2d2d44] rounded text-white text-sm resize-none focus:outline-none ai-focus'
-                  autoFocus
-                />
+                {snippets.map((snippet) => (
+                  <button
+                    key={snippet.id}
+                    onClick={() => setSelectedSnippet(snippet.id)}
+                    className={`w-full text-left px-3 py-2.5 rounded border transition-colors ${
+                      selectedSnippet === snippet.id
+                        ? 'border-fetchy-accent bg-fetchy-accent/10 text-white'
+                        : 'border-[#2d2d44] bg-[#0f0f1a] text-gray-300 hover:border-fetchy-accent/50 hover:bg-[#1a1a2e]'
+                    }`}
+                  >
+                    <div className='flex items-center gap-2 ai-text'>
+                      {snippet.icon}
+                      <span className='text-sm font-medium text-white'>{snippet.label}</span>
+                    </div>
+                    <p className='text-xs text-gray-500 mt-0.5 ml-[22px]'>{snippet.description}</p>
+                  </button>
+                ))}
               </div>
-              <p className='text-xs text-gray-500'>
-                The bug report will include all request &amp; response details automatically.
-              </p>
-              <div className='flex gap-2 justify-end'>
+              {selectedSnippet === 'bugreport' && (
+                <div className='space-y-2 pt-1'>
+                  <label className='text-sm text-gray-300 font-medium'>What did you expect? (optional)</label>
+                  <textarea
+                    value={bugNote}
+                    onChange={(e) => setBugNote(e.target.value)}
+                    placeholder='e.g., "Expected status 200 with a list of users, but got 500"'
+                    rows={3}
+                    className='w-full px-3 py-2 bg-[#0f0f1a] border border-[#2d2d44] rounded text-white text-sm resize-none focus:outline-none ai-focus'
+                  />
+                </div>
+              )}
+              {selectedSnippet === 'customchat' && (
+                <div className='space-y-2 pt-1'>
+                  <label className='text-sm text-gray-300 font-medium'>Your message</label>
+                  <textarea
+                    value={customChatMessage}
+                    onChange={(e) => setCustomChatMessage(e.target.value)}
+                    placeholder='e.g., "Why is the response missing the email field?" or "Is this a valid OAuth flow?"'
+                    rows={4}
+                    className='w-full px-3 py-2 bg-[#0f0f1a] border border-[#2d2d44] rounded text-white text-sm resize-none focus:outline-none ai-focus'
+                    autoFocus
+                  />
+                  <p className='text-xs text-gray-500'>Full request &amp; response details are automatically included in the prompt.</p>
+                </div>
+              )}
+              <div className='flex gap-2 justify-end pt-1'>
                 <button
-                  onClick={() => { setBugReportPrompt(false); setBugNote(''); }}
+                  onClick={() => { setPanelOpen(false); setSelectedSnippet(null); setBugNote(''); setCustomChatMessage(''); }}
                   className='px-4 py-2 text-sm bg-[#0f0f1a] text-gray-300 border border-[#2d2d44] rounded hover:bg-[#1a1a2e] transition-colors'
                 >
                   Cancel
                 </button>
                 <button
-                  onClick={() => handleGenerateBugReport(bugNote || 'The response is not in the expected format.')}
-                  className='px-4 py-2 text-sm ai-btn-solid rounded transition-colors flex items-center gap-2'
+                  onClick={handleAsk}
+                  disabled={!selectedSnippet || (selectedSnippet === 'customchat' && !customChatMessage.trim())}
+                  className='px-4 py-2 text-sm ai-btn-solid rounded transition-colors flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed'
                 >
-                  <Bug size={14} />
-                  Generate Report
+                  <Sparkles size={14} />
+                  Ask
                 </button>
               </div>
             </div>
@@ -866,6 +1001,8 @@ export function AIResponseToolbar({ request, response }: AIResponseToolbarProps)
             ? `api-docs-${request.method.toLowerCase()}-${request.url.replace(/[^a-z0-9]/gi, '-').slice(0, 40)}.md`
             : modal.feature === 'bugreport'
             ? `bug-report-${request.method.toLowerCase()}-${request.url.replace(/[^a-z0-9]/gi, '-').slice(0, 40)}.md`
+            : modal.feature === 'customchat'
+            ? `ai-chat-${request.method.toLowerCase()}-${request.url.replace(/[^a-z0-9]/gi, '-').slice(0, 40)}.md`
             : `ai-explanation.md`
         }
         onCreateJira={modal.feature === 'bugreport' && jiraConfigured ? handleCreateJiraBug : undefined}

--- a/src/components/RequestPanel.tsx
+++ b/src/components/RequestPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Save, Plus, Trash2, FileText, X, Terminal, Check } from 'lucide-react';
 import { useAppStore } from '../store/appStore';
-import { ApiRequest, ApiResponse, HttpMethod, KeyValue } from '../types';
+import { ApiRequest, ApiResponse, KeyValue } from '../types';
 import { executeRequest } from '../utils/httpClient';
 import { resolveRequestVariables, generateCurl, generateJavaScript, generatePython, generateJava, generateDotNet, generateGo, generateRust, generateCpp } from '../utils/helpers';
 import { resolveInheritedAuth } from '../utils/authInheritance';
@@ -11,7 +11,6 @@ import { parseCurlCommand } from '../utils/curlParser';
 import { computeKeyColWidth } from '../utils/kvTableUtils';
 import VariableInput from './VariableInput';
 import Tooltip from './Tooltip';
-import { AIRequestToolbar, AIGenerateRequestModal } from './AIAssistant';
 import BodyEditor from './request/BodyEditor';
 import AuthEditor from './request/AuthEditor';
 import ScriptsEditor from './request/ScriptsEditor';
@@ -319,54 +318,6 @@ export default function RequestPanel({ setResponse, setSentRequest, setIsLoading
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [handleSave, handleSend, handleCancel, isLoading]);
 
-  // ─── AI handlers ─────────────────────────────────────────────────────────────
-  const handleAIApplyRequest = useCallback(
-    (generated: {
-      method: string;
-      url: string;
-      headers: Array<{ key: string; value: string; enabled: boolean }>;
-      params: Array<{ key: string; value: string; enabled: boolean }>;
-      body: { type: string; raw?: string };
-      name: string;
-    }) => {
-      if (!request) return;
-      handleChange({
-        method: (generated.method || request.method) as HttpMethod,
-        url: generated.url || request.url,
-        headers: generated.headers.map((h) => ({ id: uuidv4(), ...h })),
-        params: generated.params.map((p) => ({ id: uuidv4(), ...p })),
-        body: {
-          type: generated.body.type as ApiRequest['body']['type'],
-          raw: generated.body.raw || '',
-        },
-        name: generated.name || request.name,
-      });
-    },
-    [request, handleChange]
-  );
-
-  const handleAIApplyScript = useCallback(
-    (script: string, type: 'pre-request' | 'test') => {
-      if (!request) return;
-      if (type === 'pre-request') {
-        handleChange({ preScript: script });
-        setActiveSection('preScript');
-      } else {
-        handleChange({ script });
-        setActiveSection('script');
-      }
-    },
-    [request, handleChange]
-  );
-
-  const handleAIApplyName = useCallback(
-    (name: string) => {
-      if (!request) return;
-      handleChange({ name });
-    },
-    [request, handleChange]
-  );
-
   const addKeyValue = (field: 'headers' | 'params') => {
     if (!request) return;
     const newKv: KeyValue = { id: uuidv4(), key: '', value: '', enabled: true };
@@ -602,16 +553,6 @@ export default function RequestPanel({ setResponse, setSentRequest, setIsLoading
         </Tooltip>
       </div>
 
-      {/* AI Request Toolbar */}
-      <div className="px-3 py-1.5 border-b border-fetchy-border shrink-0">
-        <AIRequestToolbar
-          request={request}
-          onOpenGenerateRequest={() => setShowAIGenerateModal(true)}
-          onApplyScript={handleAIApplyScript}
-          onApplyName={handleAIApplyName}
-        />
-      </div>
-
       {/* Section content */}
       <div className="flex-1 overflow-hidden">
         {activeSection === 'params' && renderKeyValueTable('params')}
@@ -776,12 +717,6 @@ export default function RequestPanel({ setResponse, setSentRequest, setIsLoading
         </div>
       )}
 
-      {/* AI Generate Request Modal */}
-      <AIGenerateRequestModal
-        isOpen={showAIGenerateModal}
-        onClose={() => setShowAIGenerateModal(false)}
-        onApply={handleAIApplyRequest}
-      />
     </div>
   );
 }

--- a/src/components/request/ScriptsEditor.tsx
+++ b/src/components/request/ScriptsEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react';
 import CodeEditor, { CodeEditorHandle } from '../CodeEditor';
+import { AIScriptAssistButton } from '../AIAssistant';
 
 // ─── Script Snippets Data ─────────────────────────────────────────────────────
 
@@ -55,7 +56,9 @@ export default function ScriptsEditor({ type, value, onChange }: ScriptsEditorPr
       </div>
       <ScriptSnippetsPanel
         type={type}
+        scriptValue={value}
         onInsert={(code) => editorRef.current?.insertAtCursor(code)}
+        onApply={onChange}
       />
     </div>
   );
@@ -63,7 +66,12 @@ export default function ScriptsEditor({ type, value, onChange }: ScriptsEditorPr
 
 // ─── Script Snippets Panel ────────────────────────────────────────────────────
 
-function ScriptSnippetsPanel({ type, onInsert }: { type: 'pre' | 'post'; onInsert: (code: string) => void }) {
+function ScriptSnippetsPanel({ type, scriptValue, onInsert, onApply }: {
+  type: 'pre' | 'post';
+  scriptValue: string;
+  onInsert: (code: string) => void;
+  onApply: (code: string) => void;
+}) {
   const snippets = type === 'pre' ? PRE_SCRIPT_SNIPPETS : POST_SCRIPT_SNIPPETS;
   const [expanded, setExpanded] = useState(true);
 
@@ -97,25 +105,39 @@ function ScriptSnippetsPanel({ type, onInsert }: { type: 'pre' | 'post'; onInser
         </button>
       </div>
 
-      {/* Snippet list */}
       {expanded && (
-        <div className="flex-1 overflow-y-auto p-1.5 space-y-1">
-          {snippets.map((snippet) => (
-            <button
-              key={snippet.label}
-              onClick={() => onInsert(snippet.code)}
-              className="w-full text-left px-2 py-1.5 rounded text-xs hover:bg-fetchy-border transition-colors group"
-              title={snippet.description}
-            >
-              <span className="block font-medium text-fetchy-accent group-hover:text-fetchy-accent truncate">
-                {snippet.label}
-              </span>
-              <span className="block text-fetchy-text-muted truncate mt-0.5 text-[10px]">
-                {snippet.description}
-              </span>
-            </button>
-          ))}
-        </div>
+        <>
+          {/* AI Assist — above the snippet list */}
+          <div className="px-2 pt-2 pb-1 shrink-0">
+            <AIScriptAssistButton
+              scriptType={type}
+              scriptValue={scriptValue}
+              onApply={onApply}
+            />
+          </div>
+
+          {/* Divider */}
+          <div className="mx-2 border-t border-fetchy-border shrink-0" />
+
+          {/* Snippet list */}
+          <div className="flex-1 overflow-y-auto p-1.5 space-y-1">
+            {snippets.map((snippet) => (
+              <button
+                key={snippet.label}
+                onClick={() => onInsert(snippet.code)}
+                className="w-full text-left px-2 py-1.5 rounded text-xs hover:bg-fetchy-border transition-colors group"
+                title={snippet.description}
+              >
+                <span className="block font-medium text-fetchy-accent group-hover:text-fetchy-accent truncate">
+                  {snippet.label}
+                </span>
+                <span className="block text-fetchy-text-muted truncate mt-0.5 text-[10px]">
+                  {snippet.description}
+                </span>
+              </button>
+            ))}
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/utils/aiProvider.ts
+++ b/src/utils/aiProvider.ts
@@ -372,6 +372,214 @@ ${responseBody}`,
   ];
 }
 
+export function buildCustomChatPrompt(req: ApiRequest, res: ApiResponse, userMessage: string): AIMessage[] {
+  const fullHeaders = req.headers
+    .filter((h) => h.enabled && h.key)
+    .map((h) => `${h.key}: ${h.value}`)
+    .join('\n');
+
+  const fullParams = req.params
+    .filter((p) => p.enabled && p.key)
+    .map((p) => `${p.key}=${p.value}`)
+    .join('\n');
+
+  let requestBody = '(none)';
+  if (req.body.type !== 'none') {
+    if (req.body.raw) {
+      requestBody = `[${req.body.type}]\n${req.body.raw}`;
+    } else if (req.body.type === 'form-data' && req.body.formData) {
+      requestBody = `[form-data]\n${req.body.formData.filter(f => f.enabled).map(f => `${f.key}: ${f.value}`).join('\n')}`;
+    } else if (req.body.type === 'x-www-form-urlencoded' && req.body.urlencoded) {
+      requestBody = `[x-www-form-urlencoded]\n${req.body.urlencoded.filter(f => f.enabled).map(f => `${f.key}=${f.value}`).join('&')}`;
+    }
+  }
+
+  const responseHeaders = Object.entries(res.headers)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+
+  let responseBody = res.body || '(empty)';
+  if (responseBody.length > 5000) {
+    responseBody = responseBody.slice(0, 5000) + '\n... (truncated)';
+  }
+
+  const context = `--- REQUEST ---
+Method: ${req.method}
+URL: ${req.url}
+Headers:
+${fullHeaders || '(none)'}
+Query Parameters:
+${fullParams || '(none)'}
+Body:
+${requestBody}
+Authentication: ${req.auth.type !== 'none' ? req.auth.type : '(none)'}
+
+--- RESPONSE ---
+Status: ${res.status} ${res.statusText}
+Time: ${res.time}ms
+Size: ${res.size} bytes
+Headers:
+${responseHeaders}
+Body:
+${responseBody}`;
+
+  return [
+    {
+      role: 'system',
+      content: `You are an expert API developer assistant integrated into Fetchy, a REST client application.
+The user is asking a custom question about the API request and response shown below. Answer helpfully, accurately, and concisely. Use markdown formatting where appropriate.\n\n${context}`,
+    },
+    {
+      role: 'user',
+      content: userMessage,
+    },
+  ];
+}
+
+export function buildConvertToFetchySyntaxPrompt(scriptCode: string, scriptType: 'pre' | 'post'): AIMessage[] {
+  const typeLabel = scriptType === 'pre' ? 'pre-request' : 'post-request';
+
+  const preExamples = `
+// Set an environment variable
+fetchy.environment.set('key', 'value');
+
+// Get an environment variable
+const value = fetchy.environment.get('key');
+
+// Get all environment variables
+const vars = fetchy.environment.all();
+console.log(vars);
+
+// Log output to the Console tab
+console.log('message');
+
+// Generate a UUID and store it
+const uuid = crypto.randomUUID();
+fetchy.environment.set('uuid', uuid);
+console.log('UUID:', uuid);
+
+// Store the current Unix timestamp
+const ts = String(Date.now());
+fetchy.environment.set('timestamp', ts);
+console.log('Timestamp:', ts);
+
+// Generate a random integer
+const rand = String(Math.floor(Math.random() * 1000));
+fetchy.environment.set('randomNum', rand);
+`;
+
+  const postExamples = `
+// Log the full response body
+console.log(fetchy.response.data);
+
+// Read the HTTP status code
+const status = fetchy.response.status;
+console.log('Status:', status);
+
+// Read a specific response header
+const ct = fetchy.response.headers['content-type'];
+console.log('Content-Type:', ct);
+
+// Extract a field from the JSON response and save it
+const value = fetchy.response.data.field;
+fetchy.environment.set('key', value);
+
+// Save an access token from the response body
+const token = fetchy.response.data.access_token
+  || fetchy.response.data.token;
+if (token) {
+  fetchy.environment.set('token', token);
+  console.log('Token saved.');
+}
+
+// Check status code and branch
+if (fetchy.response.status === 200) {
+  console.log('Request succeeded!');
+} else {
+  console.log('Unexpected status:', fetchy.response.status);
+}
+
+// Set an environment variable from the response
+fetchy.environment.set('key', 'value');
+
+// Get an environment variable
+const envValue = fetchy.environment.get('key');
+
+// Log all environment variables
+const allVars = fetchy.environment.all();
+console.log(allVars);
+`;
+
+  const examples = scriptType === 'pre' ? preExamples : postExamples;
+
+  return [
+    {
+      role: 'system',
+      content: `You are an expert JavaScript developer assistant integrated into Fetchy, a REST client application.
+Fetchy scripts use a built-in \`fetchy\` API for interacting with the environment and response. Convert the provided script to use proper Fetchy syntax.
+
+Fetchy API reference:
+- \`fetchy.environment.set(key, value)\` — set an environment variable
+- \`fetchy.environment.get(key)\` — get an environment variable (returns string or undefined)
+- \`fetchy.environment.all()\` — get all variables as an array of { key, value } objects
+${scriptType === 'post' ? `- \`fetchy.response.status\` — HTTP status code (number)
+- \`fetchy.response.statusText\` — status text string
+- \`fetchy.response.data\` — parsed response body (object if JSON, otherwise string)
+- \`fetchy.response.headers\` — response headers as an object (keys lowercased)
+- \`fetchy.response.time\` — response time in ms
+- \`fetchy.response.size\` — response size in bytes` : ''}
+- \`console.log(...)\` — print to the Fetchy Console tab
+
+Real Fetchy snippet examples (use these as conversion patterns):
+\`\`\`javascript${examples}\`\`\`
+
+Rules:
+- Return ONLY the converted JavaScript code, no explanations, no markdown fences.
+- Replace any fetch/axios calls, localStorage, or non-Fetchy APIs with the appropriate Fetchy equivalents.
+- Use the snippet examples above as authoritative patterns for correct Fetchy syntax.
+- Keep the original logic and comments intact.
+- If something cannot be converted, add a \`// TODO:\` comment explaining why.`,
+    },
+    {
+      role: 'user',
+      content: `Convert this ${typeLabel} script to use Fetchy syntax:\n\n${scriptCode || '// (empty script)'}`,
+    },
+  ];
+}
+
+export function buildScriptChatPrompt(scriptCode: string, scriptType: 'pre' | 'post', userMessage: string): AIMessage[] {
+  const typeLabel = scriptType === 'pre' ? 'pre-request' : 'post-request';
+  return [
+    {
+      role: 'system',
+      content: `You are an expert JavaScript developer assistant integrated into Fetchy, a REST client application.
+The user is working on a ${typeLabel} script in Fetchy. Fetchy scripts use a built-in \`fetchy\` API:
+
+- \`fetchy.environment.set(key, value)\` — set an environment variable
+- \`fetchy.environment.get(key)\` — get an environment variable (returns string or undefined)
+- \`fetchy.environment.all()\` — get all variables as an array of { key, value } objects
+${scriptType === 'post' ? `- \`fetchy.response.status\` — HTTP status code (number)
+- \`fetchy.response.statusText\` — status text string
+- \`fetchy.response.data\` — parsed response body (object if JSON, otherwise string)
+- \`fetchy.response.headers\` — response headers as an object (keys lowercased)
+- \`fetchy.response.time\` — response time in ms
+- \`fetchy.response.size\` — response size in bytes` : ''}
+- \`console.log(...)\` — print to the Fetchy Console tab
+
+Current script:
+\`\`\`javascript
+${scriptCode || '// (empty script)'}
+\`\`\`
+
+Answer the user's question helpfully and concisely. Use markdown formatting. When showing code, use \`\`\`javascript fences.`,
+    },
+    {
+      role: 'user',
+      content: userMessage,
+    },
+  ];
+}
+
 // ─── Request execution ──────────────────────────────────────────────────────
 
 export async function sendAIRequest(


### PR DESCRIPTION
- Remove Generate Request, Pre-Script, and Post-Script AI buttons from the request panel toolbar
- Add AIScriptAssistButton to Pre/Post-Script editors inside the snippets panel (full-width primary button above snippets)
  - 'Convert to Fetchy Syntax': enriches prompt with all snippet examples so the LLM converts correctly; result shown in an editable code editor
  - 'Custom Chat': freeform chat with the current script in context
- Refactor response AI toolbar from 3 inline buttons to a single 'AI Assist' button that opens a snippet-selection panel
  - Options: Explain Response, Generate Docs, Bug Report, Custom Chat
  - Custom Chat injects full request + response details into the prompt
- Add buildCustomChatPrompt, buildConvertToFetchySyntaxPrompt, buildScriptChatPrompt to aiProvider.ts
- Make the Convert result modal editable before applying to the script