### PR TITLE
fix: env var shadowing by empty collection vars & pm.response.body support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.5.68-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.5.69-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
   <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg" alt="Platform">
   <img src="https://img.shields.io/badge/electron-powered-9feaf9.svg" alt="Electron">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetchy",
-  "version": "1.5.54",
+  "version": "1.5.68",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fetchy",
-      "version": "1.5.54",
+      "version": "1.5.68",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchy",
-  "version": "1.5.68",
+  "version": "1.5.69",
   "description": "Fetchy - Local by design. Reliable by nature.",
   "main": "electron/main.js",
   "scripts": {

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -483,6 +483,9 @@ self.onmessage = function (e) {
         var d = fetchy.response.data;
         return typeof d === 'string' ? d : JSON.stringify(d);
       },
+      // pm.response.body — returns the parsed JSON body (object) so that
+      // Postman-style scripts like pm.response.body.access_token work.
+      body: fetchy.response ? fetchy.response.data : null,
       code: fetchy.response ? fetchy.response.status : 0,
       status: fetchy.response ? fetchy.response.status : 0,
       responseTime: 0,

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -32,9 +32,14 @@ export const replaceVariables = (
   }
 
   // Add collection variables (will override env vars with same key)
+  // Only override when the collection variable has a non-empty effective value so that
+  // empty collection variables (e.g. imported Postman defaults) don't shadow real env values.
   for (const variable of variables) {
     if (variable.enabled) {
-      variableMap.set(variable.key, getEffectiveValue(variable));
+      const effectiveValue = getEffectiveValue(variable);
+      if (effectiveValue !== '' || !variableMap.has(variable.key)) {
+        variableMap.set(variable.key, effectiveValue);
+      }
     }
   }
 

--- a/test/variables.test.ts
+++ b/test/variables.test.ts
@@ -72,6 +72,24 @@ describe('replaceVariables', () => {
     expect(replaceVariables('<<host>>', collVars, envVars)).toBe('prod.api.com');
   });
 
+  it('empty collection variable does not shadow a non-empty environment variable', () => {
+    const collVars = [makeVar('tenant_id', '')];
+    const envVars = [makeVar('tenant_id', 'my-tenant')];
+    expect(replaceVariables('<<tenant_id>>.example.com', collVars, envVars)).toBe('my-tenant.example.com');
+  });
+
+  it('empty collection variable does not shadow env var set via currentValue', () => {
+    const collVars = [makeVar('region', '', { initialValue: '', currentValue: '' })];
+    const envVars = [makeVar('region', 'eu1', { currentValue: 'eu1' })];
+    expect(replaceVariables('https://host.<<region>>.sws.siemens.com', collVars, envVars)).toBe('https://host.eu1.sws.siemens.com');
+  });
+
+  it('non-empty collection variable still overrides env variable', () => {
+    const collVars = [makeVar('host', 'coll.api.com')];
+    const envVars = [makeVar('host', 'env.api.com')];
+    expect(replaceVariables('<<host>>', collVars, envVars)).toBe('coll.api.com');
+  });
+
   // currentValue / value / initialValue priority
   it('prefers currentValue over value', () => {
     const vars = [makeVar('key', 'base', { currentValue: 'current' })];

--- a/test/worker-script-builder.test.ts
+++ b/test/worker-script-builder.test.ts
@@ -77,4 +77,17 @@ describe('buildWorkerSource (CSP-safe script embedding)', () => {
     expect(src1).toContain('var a = 1;');
     expect(src2).toContain('var b = 2;');
   });
+
+  it('pm.response.body is defined in the generated worker source', () => {
+    const src = buildWorkerSource('');
+    // Must expose pm.response.body (the parsed JSON data) so Postman-style
+    // scripts like `pm.response.body.access_token` work.
+    expect(src).toContain('pm.response.body') || expect(src).toContain('body:');
+  });
+
+  it('pm.response.body assignment uses fetchy.response.data', () => {
+    const src = buildWorkerSource('');
+    // The body property on pm.response must be backed by fetchy.response.data
+    expect(src).toContain('fetchy.response.data');
+  });
 });


### PR DESCRIPTION
Fix 1 — Empty collection variables no longer shadow environment variables
When a collection had a blank variable with the same name as an env variable, the empty collection variable was winning and preventing <<var>> substitution. Non-empty env variables now correctly take precedence.

Fix 2 — Added [pm.response.body](vscode-file://vscode-app/c:/Users/z003fwwn/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to Postman compatibility shim
Post-scripts using pm.response.body.access_token were failing because [pm.response.body](vscode-file://vscode-app/c:/Users/z003fwwn/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html) wasn't exposed. The parsed JSON response is now available via [pm.response.body](vscode-file://vscode-app/c:/Users/z003fwwn/AppData/Local/Programs/Microsoft%20VS%20Code/560a9dba96/resources/app/out/vs/code/electron-browser/workbench/workbench.html).