### PR TITLE
Feat/history search and collection expand collapse

### DIFF
--- a/docs/docs/features/collections.md
+++ b/docs/docs/features/collections.md
@@ -71,6 +71,15 @@ Use collection variables with `<<variable_name>>` in requests.
 
 ---
 
+## Expand / Collapse All
+
+To quickly expand or collapse all folders in a collection, right-click the collection header and choose:
+
+- **Expand All** — opens the collection and all nested folders
+- **Collapse All** — collapses the collection and all nested folders
+
+---
+
 ## Collection Runner
 
 Run all requests in a collection automatically:

--- a/docs/docs/features/request-history.md
+++ b/docs/docs/features/request-history.md
@@ -1,0 +1,66 @@
+---
+id: request-history
+title: Request History
+sidebar_label: Request History
+sidebar_position: 9
+description: Browse, search, filter, and re-send past requests from the history panel.
+---
+
+# Request History
+
+Fetchy automatically records every request you send. The **History** tab in the sidebar lets you browse, search, and re-send past requests.
+
+---
+
+## Viewing History
+
+Click the **History** tab in the sidebar to open the history panel. Each entry shows:
+
+- HTTP method badge (color-coded)
+- Request URL
+- Timestamp
+
+---
+
+## Searching
+
+Use the search bar at the top of the panel to filter entries by URL. Results update as you type.
+
+---
+
+## Filtering by HTTP Method
+
+Click the **filter icon** (funnel) next to the search bar to filter history entries by HTTP method:
+
+- **ALL** — show every request (default)
+- **GET**, **POST**, **PUT**, **PATCH**, **DELETE** — show only requests of that method
+
+The filter button turns accent-colored when an active filter is applied.
+
+---
+
+## Sorting
+
+Click the **sort icon** (arrows) to toggle the sort order:
+
+- **Newest first** (default) — most recent requests at the top
+- **Oldest first** — earliest requests at the top
+
+---
+
+## Re-sending a Request
+
+Click any history entry to open it in a new tab with all original settings (URL, method, headers, body, auth) pre-filled. You can edit and re-send it immediately.
+
+---
+
+## Configuring History Limit
+
+Go to **Settings** → **Max History Items** to control how many entries are retained (10–500). Older entries are automatically removed when the limit is reached.
+
+---
+
+## See Also
+
+- [HTTP Requests →](/docs/features/http-requests)
+- [Environments →](/docs/features/environments)

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { X, Download, FileJson, AlertCircle, Check, Globe, FolderOpen, Braces, Terminal, Sparkles, Loader2, Info } from 'lucide-react';
 import { getFirstDroppedFile } from '../utils/fileUtils';
 import { useAppStore } from '../store/appStore';

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,8 +18,6 @@ import {
 } from '@dnd-kit/sortable';
 import {
   FilePlus,
-  ChevronDown,
-  ChevronUp,
   Folder,
   Plus,
   Clock,
@@ -548,40 +546,6 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
     return null;
   };
 
-  const expandAllFolders = (folders: RequestFolder[]): RequestFolder[] => {
-    return folders.map(folder => ({
-      ...folder,
-      expanded: true,
-      folders: expandAllFolders(folder.folders),
-    }));
-  };
-
-  const collapseAllFolders = (folders: RequestFolder[]): RequestFolder[] => {
-    return folders.map(folder => ({
-      ...folder,
-      expanded: false,
-      folders: collapseAllFolders(folder.folders),
-    }));
-  };
-
-  const handleExpandAll = () => {
-    collections.forEach(collection => {
-      updateCollection(collection.id, {
-        expanded: true,
-        folders: expandAllFolders(collection.folders),
-      });
-    });
-  };
-
-  const handleCollapseAll = () => {
-    collections.forEach(collection => {
-      updateCollection(collection.id, {
-        expanded: false,
-        folders: collapseAllFolders(collection.folders),
-      });
-    });
-  };
-
   const renderFolder = (collectionId: string, folder: RequestFolder, depth: number) => {
     const folderRequests = folder.requests;
     const folderFolders = folder.folders;
@@ -830,32 +794,14 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
               )}
             </div>
             {activeTab === 'collections' && (
-              <>
-                <Tooltip content="Expand All">
-                  <button
-                    onClick={handleExpandAll}
-                    className="p-1.5 rounded border border-fetchy-border text-fetchy-text-muted hover:text-fetchy-text hover:bg-fetchy-border"
-                  >
-                    <ChevronDown size={14} />
-                  </button>
-                </Tooltip>
-                <Tooltip content="Collapse All">
-                  <button
-                    onClick={handleCollapseAll}
-                    className="p-1.5 rounded border border-fetchy-border text-fetchy-text-muted hover:text-fetchy-text hover:bg-fetchy-border"
-                  >
-                    <ChevronUp size={14} />
-                  </button>
-                </Tooltip>
-                <Tooltip content="Import Collection">
-                  <button
-                    onClick={onImport}
-                    className="p-1.5 rounded border border-fetchy-border text-fetchy-text-muted hover:text-fetchy-text hover:bg-fetchy-border"
-                  >
-                    <Download size={14} />
-                  </button>
-                </Tooltip>
-              </>
+              <Tooltip content="Import Collection">
+                <button
+                  onClick={onImport}
+                  className="p-1.5 rounded border border-fetchy-border text-fetchy-text-muted hover:text-fetchy-text hover:bg-fetchy-border"
+                >
+                  <Download size={14} />
+                </button>
+              </Tooltip>
             )}
             <div className="relative">
               <Tooltip content="Filter & Sort">

--- a/src/components/sidebar/HistoryPanel.tsx
+++ b/src/components/sidebar/HistoryPanel.tsx
@@ -1,4 +1,5 @@
-import { Clock } from 'lucide-react';
+import { useState } from 'react';
+import { Clock, Search } from 'lucide-react';
 import { useAppStore } from '../../store/appStore';
 import { RequestHistoryItem } from '../../types';
 import { getMethodBgColor } from '../../utils/helpers';
@@ -30,6 +31,18 @@ function formatResponseSize(bytes: number): string {
 export default function HistoryPanel({ onHistoryItemClick }: HistoryPanelProps) {
   const history = useAppStore(s => s.history);
   const clearHistory = useAppStore(s => s.clearHistory);
+  const [search, setSearch] = useState('');
+
+  const filtered = search.trim()
+    ? history.filter(item => {
+        const q = search.toLowerCase();
+        return (
+          item.request.url.toLowerCase().includes(q) ||
+          (item.request.name || '').toLowerCase().includes(q) ||
+          item.request.method.toLowerCase().includes(q)
+        );
+      })
+    : history;
 
   if (history.length === 0) {
     return (
@@ -43,8 +56,18 @@ export default function HistoryPanel({ onHistoryItemClick }: HistoryPanelProps) 
 
   return (
     <div>
+      <div className="relative mb-2">
+        <Search size={13} className="absolute left-2 top-1/2 -translate-y-1/2 text-fetchy-text-muted pointer-events-none" />
+        <input
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="Search history..."
+          className="w-full pl-7 pr-2 py-1.5 text-xs bg-fetchy-card border border-fetchy-border rounded text-fetchy-text placeholder-fetchy-text-muted focus:outline-none focus:border-fetchy-accent"
+        />
+      </div>
       <div className="flex items-center justify-between mb-2 px-1">
-        <span className="text-xs text-fetchy-text-muted">{history.length} request{history.length !== 1 ? 's' : ''}</span>
+        <span className="text-xs text-fetchy-text-muted">{filtered.length} request{filtered.length !== 1 ? 's' : ''}</span>
         <button
           onClick={clearHistory}
           className="text-xs text-red-400 hover:text-red-300"
@@ -52,7 +75,7 @@ export default function HistoryPanel({ onHistoryItemClick }: HistoryPanelProps) 
           Clear All
         </button>
       </div>
-      {history.map(item => (
+      {filtered.map(item => (
         <div
           key={item.id}
           className="tree-item px-2 py-2 cursor-pointer group rounded hover:bg-fetchy-border mb-1 border border-transparent hover:border-fetchy-border"

--- a/src/components/sidebar/HistoryPanel.tsx
+++ b/src/components/sidebar/HistoryPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Clock, Search } from 'lucide-react';
+import { Clock, X, Filter, ArrowUpDown } from 'lucide-react';
 import { useAppStore } from '../../store/appStore';
 import { RequestHistoryItem } from '../../types';
 import { getMethodBgColor } from '../../utils/helpers';
@@ -7,6 +7,9 @@ import { getMethodBgColor } from '../../utils/helpers';
 interface HistoryPanelProps {
   onHistoryItemClick?: (item: RequestHistoryItem) => void;
 }
+
+type HistorySortOption = 'date-desc' | 'date-asc';
+type HistoryFilterMethod = 'all' | 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 function formatHistoryTime(timestamp: number): string {
   const now = Date.now();
@@ -32,17 +35,26 @@ export default function HistoryPanel({ onHistoryItemClick }: HistoryPanelProps) 
   const history = useAppStore(s => s.history);
   const clearHistory = useAppStore(s => s.clearHistory);
   const [search, setSearch] = useState('');
+  const [sortOption, setSortOption] = useState<HistorySortOption>('date-desc');
+  const [filterMethod, setFilterMethod] = useState<HistoryFilterMethod>('all');
+  const [showFilterMenu, setShowFilterMenu] = useState(false);
 
-  const filtered = search.trim()
-    ? history.filter(item => {
-        const q = search.toLowerCase();
-        return (
-          item.request.url.toLowerCase().includes(q) ||
-          (item.request.name || '').toLowerCase().includes(q) ||
-          item.request.method.toLowerCase().includes(q)
-        );
-      })
-    : history;
+  const hasActiveFilters = filterMethod !== 'all' || sortOption !== 'date-desc';
+
+  let filtered = history.filter(item => {
+    const q = search.toLowerCase().trim();
+    const matchesSearch = !q || (
+      item.request.url.toLowerCase().includes(q) ||
+      (item.request.name || '').toLowerCase().includes(q) ||
+      item.request.method.toLowerCase().includes(q)
+    );
+    const matchesMethod = filterMethod === 'all' || item.request.method === filterMethod;
+    return matchesSearch && matchesMethod;
+  });
+
+  filtered = [...filtered].sort((a, b) =>
+    sortOption === 'date-asc' ? a.timestamp - b.timestamp : b.timestamp - a.timestamp
+  );
 
   if (history.length === 0) {
     return (
@@ -56,15 +68,86 @@ export default function HistoryPanel({ onHistoryItemClick }: HistoryPanelProps) 
 
   return (
     <div>
-      <div className="relative mb-2">
-        <Search size={13} className="absolute left-2 top-1/2 -translate-y-1/2 text-fetchy-text-muted pointer-events-none" />
-        <input
-          type="text"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          placeholder="Search history..."
-          className="w-full pl-7 pr-2 py-1.5 text-xs bg-fetchy-card border border-fetchy-border rounded text-fetchy-text placeholder-fetchy-text-muted focus:outline-none focus:border-fetchy-accent"
-        />
+      <div className="flex items-center gap-2 mb-2">
+        <div className="flex-1 relative">
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search history..."
+            className="w-full pl-3 pr-7 py-1.5 text-sm bg-fetchy-bg border border-fetchy-border rounded focus:outline-none focus:border-fetchy-accent"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-fetchy-text-muted hover:text-fetchy-text"
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
+        <div className="relative">
+          <button
+            onClick={() => setShowFilterMenu(v => !v)}
+            className={`p-1.5 rounded border ${
+              hasActiveFilters
+                ? 'bg-fetchy-accent/20 border-fetchy-accent text-fetchy-accent'
+                : 'border-fetchy-border text-fetchy-text-muted hover:text-fetchy-text hover:bg-fetchy-border'
+            }`}
+          >
+            <Filter size={14} />
+          </button>
+          {showFilterMenu && (
+            <>
+              <div className="fixed inset-0 z-40" onClick={() => setShowFilterMenu(false)} />
+              <div className="absolute right-0 top-full mt-1 z-50 bg-fetchy-dropdown border border-fetchy-border rounded-lg shadow-xl py-2 min-w-[180px]">
+                <div className="px-3 py-1 text-xs font-medium text-fetchy-text-muted uppercase">Filter by Method</div>
+                {(['all', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const).map(method => (
+                  <button
+                    key={method}
+                    className={`w-full px-3 py-1.5 text-left text-sm hover:bg-fetchy-border flex items-center gap-2 ${filterMethod === method ? 'text-fetchy-accent' : ''}`}
+                    onClick={() => setFilterMethod(method)}
+                  >
+                    {method === 'all' ? 'All Methods' : method}
+                    {filterMethod === method && <span className="ml-auto">✓</span>}
+                  </button>
+                ))}
+                <hr className="my-2 border-fetchy-border" />
+                <div className="px-3 py-1 text-xs font-medium text-fetchy-text-muted uppercase flex items-center gap-1">
+                  <ArrowUpDown size={12} /> Sort by
+                </div>
+                {([
+                  { value: 'date-desc', label: 'Date (Newest First)' },
+                  { value: 'date-asc',  label: 'Date (Oldest First)' },
+                ] as const).map(option => (
+                  <button
+                    key={option.value}
+                    className={`w-full px-3 py-1.5 text-left text-sm hover:bg-fetchy-border flex items-center gap-2 ${sortOption === option.value ? 'text-fetchy-accent' : ''}`}
+                    onClick={() => setSortOption(option.value)}
+                  >
+                    {option.label}
+                    {sortOption === option.value && <span className="ml-auto">✓</span>}
+                  </button>
+                ))}
+                {hasActiveFilters && (
+                  <>
+                    <hr className="my-2 border-fetchy-border" />
+                    <button
+                      className="w-full px-3 py-1.5 text-left text-sm hover:bg-fetchy-border text-red-400"
+                      onClick={() => {
+                        setFilterMethod('all');
+                        setSortOption('date-desc');
+                        setShowFilterMenu(false);
+                      }}
+                    >
+                      Clear All Filters
+                    </button>
+                  </>
+                )}
+              </div>
+            </>
+          )}
+        </div>
       </div>
       <div className="flex items-center justify-between mb-2 px-1">
         <span className="text-xs text-fetchy-text-muted">{filtered.length} request{filtered.length !== 1 ? 's' : ''}</span>

--- a/src/components/sidebar/SidebarContextMenu.tsx
+++ b/src/components/sidebar/SidebarContextMenu.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import {
   FilePlus,
   FolderPlus,
@@ -78,6 +79,21 @@ export default function SidebarContextMenu({
     name: string;
   } | null>(null);
 
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  useEffect(() => {
+    const el = menuRef.current;
+    if (!el) return;
+    const { offsetWidth: w, offsetHeight: h } = el;
+    const margin = 6;
+    let left = contextMenu.x;
+    let top = contextMenu.y;
+    if (left + w + margin > window.innerWidth)  left = Math.max(margin, left - w);
+    if (top  + h + margin > window.innerHeight) top  = Math.max(margin, top  - h);
+    setPos({ left, top });
+  }, [contextMenu.x, contextMenu.y]);
+
   const handleExportCollection = (collectionId: string) => {
     const collection = collections.find(c => c.id === collectionId);
     if (!collection) return;
@@ -94,12 +110,16 @@ export default function SidebarContextMenu({
     URL.revokeObjectURL(url);
   };
 
-  return (
+  return createPortal(
     <>
       <div className="fixed inset-0 z-40" onClick={closeContextMenu} />
       <div
+        ref={menuRef}
         className="context-menu fixed z-50 bg-fetchy-dropdown border border-fetchy-border rounded-lg shadow-xl py-1 min-w-[160px]"
-        style={{ left: contextMenu.x, top: contextMenu.y }}
+        style={pos
+          ? { left: pos.left, top: pos.top }
+          : { left: contextMenu.x, top: contextMenu.y, visibility: 'hidden' }
+        }
       >
         {contextMenu.type === 'collection' && (
           <>
@@ -497,5 +517,5 @@ export default function SidebarContextMenu({
         </div>
       )}
     </>
-  );
+  , document.body);
 }

--- a/src/components/sidebar/SidebarContextMenu.tsx
+++ b/src/components/sidebar/SidebarContextMenu.tsx
@@ -5,6 +5,8 @@ import {
   ChevronRight,
   ChevronDown,
   ChevronUp,
+  ChevronsDownUp,
+  ChevronsUpDown,
   Folder,
   Trash2,
   Edit2,
@@ -66,6 +68,7 @@ export default function SidebarContextMenu({
     moveFolder,
     reorderRequests,
     openTab,
+    setAllFoldersExpanded,
   } = useAppStore();
 
   const [pendingDelete, setPendingDelete] = useState<{
@@ -172,6 +175,25 @@ export default function SidebarContextMenu({
               }}
             >
               <Settings size={14} /> Configure
+            </button>
+            <hr className="my-1 border-fetchy-border" />
+            <button
+              className="w-full px-3 py-2 text-left text-sm hover:bg-fetchy-border flex items-center gap-2"
+              onClick={() => {
+                setAllFoldersExpanded(contextMenu.collectionId, true);
+                closeContextMenu();
+              }}
+            >
+              <ChevronsUpDown size={14} /> Expand All
+            </button>
+            <button
+              className="w-full px-3 py-2 text-left text-sm hover:bg-fetchy-border flex items-center gap-2"
+              onClick={() => {
+                setAllFoldersExpanded(contextMenu.collectionId, false);
+                closeContextMenu();
+              }}
+            >
+              <ChevronsDownUp size={14} /> Collapse All
             </button>
             <hr className="my-1 border-fetchy-border" />
             <button

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -61,6 +61,7 @@ interface AppStore {
   updateFolder: (collectionId: string, folderId: string, updates: Partial<RequestFolder>) => void;
   deleteFolder: (collectionId: string, folderId: string) => void;
   toggleFolderExpanded: (collectionId: string, folderId: string) => void;
+  setAllFoldersExpanded: (collectionId: string, expanded: boolean) => void;
   reorderFolders: (collectionId: string, parentFolderId: string | null, fromIndex: number, toIndex: number) => void;
   moveFolder: (
     sourceCollectionId: string,
@@ -357,6 +358,20 @@ export const useAppStore = create<AppStore>()(
               state.collections[collectionIndex].folders
             );
           }
+        });
+      },
+
+      setAllFoldersExpanded: (collectionId: string, expanded: boolean) => {
+        set(state => {
+          const collection = state.collections.find(c => c.id === collectionId);
+          if (!collection) return;
+          const recurse = (folders: RequestFolder[]) => {
+            for (const folder of folders) {
+              folder.expanded = expanded;
+              recurse(folder.folders);
+            }
+          };
+          recurse(collection.folders);
         });
       },
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -365,6 +365,7 @@ export const useAppStore = create<AppStore>()(
         set(state => {
           const collection = state.collections.find(c => c.id === collectionId);
           if (!collection) return;
+          collection.expanded = expanded;
           const recurse = (folders: RequestFolder[]) => {
             for (const folder of folders) {
               folder.expanded = expanded;

--- a/test/components/Sidebar.test.tsx
+++ b/test/components/Sidebar.test.tsx
@@ -321,27 +321,6 @@ describe('Sidebar', () => {
     expect(screen.getByText('Clear All Filters')).toBeDefined();
   });
 
-  // 10. Expand all / collapse all collections
-  it('calls updateCollection for expand all', () => {
-    const col = makeCollection();
-    mockStores({ collections: [col] });
-    render(<Sidebar onImport={onImport} />);
-    const expandBtn = screen.getAllByRole('button').find(b => b.querySelector('[data-testid="icon-chevron-down"]'));
-    expect(expandBtn).toBeDefined();
-    fireEvent.click(expandBtn!);
-    expect(updateCollection).toHaveBeenCalledWith('col-1', expect.objectContaining({ expanded: true }));
-  });
-
-  it('calls updateCollection for collapse all', () => {
-    const col = makeCollection();
-    mockStores({ collections: [col] });
-    render(<Sidebar onImport={onImport} />);
-    const collapseBtn = screen.getAllByRole('button').find(b => b.querySelector('[data-testid="icon-chevron-up"]'));
-    expect(collapseBtn).toBeDefined();
-    fireEvent.click(collapseBtn!);
-    expect(updateCollection).toHaveBeenCalledWith('col-1', expect.objectContaining({ expanded: false }));
-  });
-
   // 11. Click on a request opens a tab
   it('opens tab when request is clicked', () => {
     const req = makeRequest();


### PR DESCRIPTION
## Summary

This PR improves the sidebar UX across several areas.

## Changes

### History Panel
- Added filter by HTTP method (ALL / GET / POST / PUT / PATCH / DELETE)
- Added sort by date (newest first / oldest first)
- Filter button turns accent color when active filters are applied
- Aligned search input style with the Collections and API Docs tabs

### Collections Sidebar
- Removed "Expand All" / "Collapse All" buttons  are now available exclusively via the right-click context menu on each collection
- Fixed `setAllFoldersExpanded` to also toggle the collection root's own `expanded` flag (previously only child folders were toggled)

### Context Menu
- Replaced inline positioning with `createPortal` (renders to `document.body`)
- Added smart flip logic: menu opens upward when triggered near the bottom of the screen, preventing items from being cut off
- Fixes the cutoff issue caused by `overflow: hidden` on sidebar containers and DND Kit's CSS transforms breaking `position: fixed`