### PR TITLE
improv: history panel search/filter/sort and context menu flip fix

### DIFF
--- a/docs/docs/features/request-history.md
+++ b/docs/docs/features/request-history.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 4
+title: Request History
+---
+
+# Request History
+
+Fetchy automatically records every HTTP request you send, so you can revisit, replay, or reference them at any time.
+
+---
+
+## Viewing History
+
+Click the **History** tab (clock icon) in the sidebar to see all your past requests. Each entry shows:
+
+- **Method badge** – color-coded HTTP verb (GET, POST, PUT, PATCH, DELETE)
+- **URL** – the full request URL
+- **Timestamp** – when the request was made
+- **Status & size** – the response status code and body size (when available)
+
+Click any history entry to load it into the request panel.
+
+---
+
+## Searching History
+
+Use the **search bar** at the top of the History panel to filter entries by URL or request name. The list updates as you type.
+
+To clear the search, click the **×** button inside the input field.
+
+---
+
+## Filtering & Sorting
+
+Click the **Filter** icon (funnel) in the toolbar next to the search bar to open the filter/sort dropdown. The icon turns accent color when any non-default option is active.
+
+### Filter by Method
+
+Show only requests of a specific HTTP method:
+
+| Option | Shows |
+|--------|-------|
+| **All Methods** | All requests (default) |
+| **GET** | GET requests only |
+| **POST** | POST requests only |
+| **PUT** | PUT requests only |
+| **PATCH** | PATCH requests only |
+| **DELETE** | DELETE requests only |
+
+### Sort by
+
+| Option | Description |
+|--------|-------------|
+| **Newest First** | Most recent requests at the top (default) |
+| **Oldest First** | Earliest requests at the top |
+| **Name (A-Z)** | Alphabetical ascending by request name or URL |
+| **Name (Z-A)** | Alphabetical descending by request name or URL |
+| **Method** | Alphabetical order by HTTP method |
+
+Click **Clear All Filters** at the bottom of the dropdown to reset all options to their defaults.
+
+---
+
+## Clearing History
+
+Click **Clear All** (top-right of the history list) to permanently remove all history entries. This action cannot be undone.
+
+The maximum number of history entries retained can be configured in **Settings → Max History Items**.

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -69,6 +69,8 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
     openApiDocuments,
   } = useAppStore();
 
+  const history = useAppStore(s => s.history);
+
   // Determine which request is currently active based on the open tab
   const activeStoreTab = tabs.find(t => t.id === activeTabId);
   const activeRequestId = activeStoreTab?.requestId ?? null;
@@ -98,6 +100,12 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
   const [apiSearchQuery, setApiSearchQuery] = useState('');
   const [apiSortOption, setApiSortOption] = useState<'name-asc' | 'name-desc' | 'format' | 'created'>('created');
   const [showApiFilterMenu, setShowApiFilterMenu] = useState(false);
+
+  // History filter and sort states
+  const [historySearch, setHistorySearch] = useState('');
+  const [historyFilterMethod, setHistoryFilterMethod] = useState<'all' | 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'>('all');
+  const [historySortOption, setHistorySortOption] = useState<'date-desc' | 'date-asc' | 'name-asc' | 'name-desc' | 'method'>('date-desc');
+  const [showHistoryFilterMenu, setShowHistoryFilterMenu] = useState(false);
   const [apiFilterFormat, setApiFilterFormat] = useState<'all' | 'yaml' | 'json'>('all');
 
   // Move to submenu state
@@ -741,6 +749,7 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
   const collectionIds = filteredCollections.map(c => `collection-${c.id}`);
 
   const hasActiveFilters = searchQuery || filterMethod !== 'all' || sortOption !== 'created';
+  const hasActiveHistoryFilters = historySearch || historyFilterMethod !== 'all' || historySortOption !== 'date-desc';
 
   return (
     <div ref={sidebarRef} className="h-full bg-fetchy-sidebar flex flex-col border-r border-fetchy-border">
@@ -795,30 +804,34 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
         </div>
       </div>
 
-      {/* Filter/Search Bar - Only for collections and API tabs */}
-      {(activeTab === 'collections' && collections.length > 0) || (activeTab === 'api' && openApiDocuments.length > 0) ? (
+      {/* Filter/Search Bar - Collections, API, and History tabs */}
+      {(activeTab === 'collections' && collections.length > 0) || (activeTab === 'api' && openApiDocuments.length > 0) || (activeTab === 'history' && history.length > 0) ? (
         <div className={`p-2 border-b border-fetchy-border transition-colors duration-150 ${isFocused ? 'sidebar-focused' : ''}`}>
           <div className="flex items-center gap-2">
             <div className="flex-1 relative">
               <input
                 ref={activeTab === 'collections' ? searchInputRef : undefined}
                 type="text"
-                placeholder={activeTab === 'collections' ? "Search requests..." : "Search API specs..."}
-                value={activeTab === 'collections' ? searchQuery : apiSearchQuery}
+                placeholder={activeTab === 'collections' ? "Search requests..." : activeTab === 'history' ? "Search history..." : "Search API specs..."}
+                value={activeTab === 'collections' ? searchQuery : activeTab === 'history' ? historySearch : apiSearchQuery}
                 onChange={(e) => {
                   if (activeTab === 'collections') {
                     setSearchQuery(e.target.value);
+                  } else if (activeTab === 'history') {
+                    setHistorySearch(e.target.value);
                   } else {
                     setApiSearchQuery(e.target.value);
                   }
                 }}
                 className="w-full pl-3 pr-7 py-1.5 text-sm bg-fetchy-bg border border-fetchy-border rounded focus:outline-none focus:border-fetchy-accent"
               />
-              {((activeTab === 'collections' && searchQuery) || (activeTab === 'api' && apiSearchQuery)) && (
+              {((activeTab === 'collections' && searchQuery) || (activeTab === 'api' && apiSearchQuery) || (activeTab === 'history' && historySearch)) && (
                 <button
                   onClick={() => {
                     if (activeTab === 'collections') {
                       setSearchQuery('');
+                    } else if (activeTab === 'history') {
+                      setHistorySearch('');
                     } else {
                       setApiSearchQuery('');
                     }
@@ -863,12 +876,15 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
                   onClick={() => {
                     if (activeTab === 'collections') {
                       setShowFilterMenu(!showFilterMenu);
+                    } else if (activeTab === 'history') {
+                      setShowHistoryFilterMenu(!showHistoryFilterMenu);
                     } else {
                       setShowApiFilterMenu(!showApiFilterMenu);
                     }
                   }}
                   className={`p-1.5 rounded border ${
                     (activeTab === 'collections' && hasActiveFilters) ||
+                    (activeTab === 'history' && hasActiveHistoryFilters) ||
                     (activeTab === 'api' && (apiSearchQuery || apiFilterFormat !== 'all' || apiSortOption !== 'created'))
                       ? 'bg-fetchy-accent/20 border-fetchy-accent text-fetchy-accent'
                       : 'border-fetchy-border text-fetchy-text-muted hover:text-fetchy-text hover:bg-fetchy-border'
@@ -991,6 +1007,60 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
                   </div>
                 </>
               )}
+              {activeTab === 'history' && showHistoryFilterMenu && (
+                <>
+                  <div className="fixed inset-0 z-40" onClick={() => setShowHistoryFilterMenu(false)} />
+                  <div className="absolute right-0 top-full mt-1 z-50 bg-fetchy-dropdown border border-fetchy-border rounded-lg shadow-xl py-2 min-w-[180px]">
+                    <div className="px-3 py-1 text-xs font-medium text-fetchy-text-muted uppercase">Filter by Method</div>
+                    {(['all', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const).map((method) => (
+                      <button
+                        key={method}
+                        className={`w-full px-3 py-1.5 text-left text-sm hover:bg-fetchy-border flex items-center gap-2 ${historyFilterMethod === method ? 'text-fetchy-accent' : ''}`}
+                        onClick={() => setHistoryFilterMethod(method)}
+                      >
+                        {method === 'all' ? 'All Methods' : method}
+                        {historyFilterMethod === method && <span className="ml-auto">✓</span>}
+                      </button>
+                    ))}
+                    <hr className="my-2 border-fetchy-border" />
+                    <div className="px-3 py-1 text-xs font-medium text-fetchy-text-muted uppercase flex items-center gap-1">
+                      <ArrowUpDown size={12} /> Sort by
+                    </div>
+                    {([
+                      { value: 'date-desc', label: 'Newest First' },
+                      { value: 'date-asc', label: 'Oldest First' },
+                      { value: 'name-asc', label: 'Name (A-Z)' },
+                      { value: 'name-desc', label: 'Name (Z-A)' },
+                      { value: 'method', label: 'Method' },
+                    ] as const).map((option) => (
+                      <button
+                        key={option.value}
+                        className={`w-full px-3 py-1.5 text-left text-sm hover:bg-fetchy-border flex items-center gap-2 ${historySortOption === option.value ? 'text-fetchy-accent' : ''}`}
+                        onClick={() => setHistorySortOption(option.value)}
+                      >
+                        {option.label}
+                        {historySortOption === option.value && <span className="ml-auto">✓</span>}
+                      </button>
+                    ))}
+                    {hasActiveHistoryFilters && (
+                      <>
+                        <hr className="my-2 border-fetchy-border" />
+                        <button
+                          className="w-full px-3 py-1.5 text-left text-sm hover:bg-fetchy-border text-red-400"
+                          onClick={() => {
+                            setHistorySearch('');
+                            setHistoryFilterMethod('all');
+                            setHistorySortOption('date-desc' as const);
+                            setShowHistoryFilterMenu(false);
+                          }}
+                        >
+                          Clear All Filters
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -1062,7 +1132,12 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
             onResetSort={() => setApiSortOption('created')}
           />
         ) : activeTab === 'history' ? (
-          <HistoryPanel onHistoryItemClick={onHistoryItemClick} />
+          <HistoryPanel
+            onHistoryItemClick={onHistoryItemClick}
+            search={historySearch}
+            filterMethod={historyFilterMethod}
+            sortOption={historySortOption}
+          />
         ) : null}
       </div>
 

--- a/src/components/sidebar/HistoryPanel.tsx
+++ b/src/components/sidebar/HistoryPanel.tsx
@@ -5,6 +5,9 @@ import { getMethodBgColor } from '../../utils/helpers';
 
 interface HistoryPanelProps {
   onHistoryItemClick?: (item: RequestHistoryItem) => void;
+  search: string;
+  filterMethod: 'all' | 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  sortOption: 'date-desc' | 'date-asc' | 'name-asc' | 'name-desc' | 'method';
 }
 
 function formatHistoryTime(timestamp: number): string {
@@ -27,9 +30,26 @@ function formatResponseSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export default function HistoryPanel({ onHistoryItemClick }: HistoryPanelProps) {
+export default function HistoryPanel({ onHistoryItemClick, search, filterMethod, sortOption }: HistoryPanelProps) {
   const history = useAppStore(s => s.history);
   const clearHistory = useAppStore(s => s.clearHistory);
+
+  const filtered = history
+    .filter(item => {
+      const matchesMethod = filterMethod === 'all' || item.request.method === filterMethod;
+      const matchesSearch = !search || item.request.url.toLowerCase().includes(search.toLowerCase()) || (item.request.name || '').toLowerCase().includes(search.toLowerCase());
+      return matchesMethod && matchesSearch;
+    })
+    .sort((a, b) => {
+      if (sortOption === 'date-asc') return a.timestamp - b.timestamp;
+      if (sortOption === 'date-desc') return b.timestamp - a.timestamp;
+      const nameA = (a.request.name || a.request.url).toLowerCase();
+      const nameB = (b.request.name || b.request.url).toLowerCase();
+      if (sortOption === 'name-asc') return nameA.localeCompare(nameB);
+      if (sortOption === 'name-desc') return nameB.localeCompare(nameA);
+      if (sortOption === 'method') return a.request.method.localeCompare(b.request.method);
+      return 0;
+    });
 
   if (history.length === 0) {
     return (
@@ -44,7 +64,7 @@ export default function HistoryPanel({ onHistoryItemClick }: HistoryPanelProps) 
   return (
     <div>
       <div className="flex items-center justify-between mb-2 px-1">
-        <span className="text-xs text-fetchy-text-muted">{history.length} request{history.length !== 1 ? 's' : ''}</span>
+        <span className="text-xs text-fetchy-text-muted">{filtered.length} request{filtered.length !== 1 ? 's' : ''}</span>
         <button
           onClick={clearHistory}
           className="text-xs text-red-400 hover:text-red-300"
@@ -52,7 +72,7 @@ export default function HistoryPanel({ onHistoryItemClick }: HistoryPanelProps) 
           Clear All
         </button>
       </div>
-      {history.map(item => (
+      {filtered.map(item => (
         <div
           key={item.id}
           className="tree-item px-2 py-2 cursor-pointer group rounded hover:bg-fetchy-border mb-1 border border-transparent hover:border-fetchy-border"

--- a/src/components/sidebar/SidebarContextMenu.tsx
+++ b/src/components/sidebar/SidebarContextMenu.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import {
   FilePlus,
   FolderPlus,
@@ -75,6 +76,21 @@ export default function SidebarContextMenu({
     name: string;
   } | null>(null);
 
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  useEffect(() => {
+    const el = menuRef.current;
+    if (!el) return;
+    const { offsetWidth: w, offsetHeight: h } = el;
+    const margin = 6;
+    let left = contextMenu.x;
+    let top = contextMenu.y;
+    if (left + w + margin > window.innerWidth) left = Math.max(margin, left - w);
+    if (top + h + margin > window.innerHeight) top = Math.max(margin, top - h);
+    setPos({ left, top });
+  }, [contextMenu.x, contextMenu.y]);
+
   const handleExportCollection = (collectionId: string) => {
     const collection = collections.find(c => c.id === collectionId);
     if (!collection) return;
@@ -91,12 +107,13 @@ export default function SidebarContextMenu({
     URL.revokeObjectURL(url);
   };
 
-  return (
+  return createPortal(
     <>
       <div className="fixed inset-0 z-40" onClick={closeContextMenu} />
       <div
+        ref={menuRef}
         className="context-menu fixed z-50 bg-fetchy-dropdown border border-fetchy-border rounded-lg shadow-xl py-1 min-w-[160px]"
-        style={{ left: contextMenu.x, top: contextMenu.y }}
+        style={pos ? { left: pos.left, top: pos.top } : { left: contextMenu.x, top: contextMenu.y, visibility: 'hidden' }}
       >
         {contextMenu.type === 'collection' && (
           <>
@@ -474,6 +491,7 @@ export default function SidebarContextMenu({
           </div>
         </div>
       )}
-    </>
+    </>,
+    document.body
   );
 }


### PR DESCRIPTION
## Summary

Two focused UX improvements to the sidebar.

---

### 1. History Panel — Search, Filter & Sort

The History tab now has the same search/filter/sort experience as the Collections and API Docs tabs.

- **Search bar** — filters history entries by URL or request name as you type (with × clear button)
- **Filter by Method** — All Methods / GET / POST / PUT / PATCH / DELETE
- **Sort by** — Newest First (default) / Oldest First / Name (A-Z) / Name (Z-A) / Method
- Filter icon in the toolbar turns accent color when any non-default option is active
- "Clear All Filters" resets everything to defaults

Controls live in the shared sidebar toolbar (not inside the panel itself), consistent with Collections and API Docs.

---

### 2. Context Menu — Portal + Smart Flip

The right-click context menu was being clipped when opened near the bottom of the sidebar because of `overflow: hidden` on the sidebar container and CSS `transform` applied by DND Kit on draggable items (which breaks `position: fixed` stacking context).

**Fix:**
- Wrapped the menu in `createPortal` so it renders directly to `document.body`, escaping all parent stacking/overflow constraints
- Added a `useEffect` that measures the rendered menu height and flips it upward if it would overflow the viewport bottom

---

### Docs

Added `docs/docs/features/request-history.md` covering search, filter by method, and all sort options.