### PR TITLE
feat: rename welcome screen title from Fetchy to Kechy

### DIFF
--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -38,7 +38,7 @@ export default function WelcomeScreen({ onImportRequest, onImportCollection, onI
           />
         </div>
         <h1 className="text-2xl font-bold text-fetchy-text mb-1">
-          Welcome to Fetchy
+          Welcome to Kechy
         </h1>
         <p className="text-fetchy-accent italic mb-2 text-sm">Local by design. Reliable by nature.</p>
         <p className="text-fetchy-text-muted mb-5 text-sm">


### PR DESCRIPTION
## Summary
Renames the welcome screen heading from 'Welcome to Fetchy' to 'Welcome to Kechy'.

---

## 🤖 AI Review

**Reviewed by:** Metis - Reviewer (Pantheon)
**Date:** 2026-06-18
**Verdict:** ❌ Request Changes

---

### Summary

PR #89 changes a single line in `src/components/WelcomeScreen.tsx`, replacing the heading text `Welcome to Fetchy` with `Welcome to Kechy`. The change is syntactically correct and introduces no functional regressions, but it creates a visible brand inconsistency across the application and the motivation for the rename is unclear.

---

### Findings

#### 🔴 Blocking — Suspected typo or unauthorized partial rebrand

The string `Kechy` does not appear anywhere else in the repository. The entire codebase consistently refers to the product as **Fetchy** — in the window title, `package.json` `productName`, the About modal, the workspace creation screen, the docs site, and all alt text. Merging this PR as-is will show users `Welcome to Kechy` on the welcome screen while every other surface (title bar, menus, about dialog) still reads `Fetchy`. This is almost certainly either:

1. An accidental key-slip typo (`F` → `K`), or
2. An intentional but massively incomplete brand rename.

Either way the change must not be merged without resolution.

#### 🟡 Major — Alt text inconsistency in the same file

`src/components/WelcomeScreen.tsx` line 36 (not touched by this PR) still reads:

```tsx
<img src="./logo.jpg" alt="Fetchy" className="w-20 h-20 mx-auto" />
```

The logo immediately above the heading now has `alt="Fetchy"` while the heading says `Welcome to Kechy`. This is a direct accessibility inconsistency within the same component.

#### 🟡 Major — Many other Fetchy brand occurrences left unchanged

If this rename is intentional, the following files also need updating (non-exhaustive):

| File | Current value |
|---|---|
| `index.html:10` | `<title>Fetchy</title>` |
| `src/App.tsx:220` | `alt="Fetchy"` |
| `src/components/AboutModal.tsx:65` | `alt="Fetchy"` |
| `src/components/CreateWorkspaceScreen.tsx:84` | `alt="Fetchy"` |
| `package.json` | `productName`, `description`, `appId` |
| `electron/ipc/workspaceHandler.js:142` | dialog title string |

#### 🔵 Minor — No test for heading content

The existing `test/components/WelcomeScreen.test.tsx` tests interaction behavior only. No assertion covers the heading text. A text-content change is a natural opportunity to add:

```tsx
expect(screen.getByRole('heading', { name: /Welcome to Kechy/i })).toBeInTheDocument();
```

#### 🔵 Minor — No issue reference

The PR description does not link to a GitHub issue or product decision that authorizes this branding change. Per the project's contribution guidelines, changes should be traceable to a recorded issue.

---

### Positives

- Diff is minimal and laser-focused (1 addition, 1 deletion).
- No regressions in logic, behaviour, or existing tests.
- Clean commit message format.

---

### Recommended Action

**Before merging:** Author should either (a) confirm `Kechy` is intentional and extend the rename to all occurrences listed above (including `alt="Fetchy"` in the same file), or (b) correct the typo and revert the heading back to `Welcome to Fetchy`.
