### PR TITLE
fix(postman): handle single key/value object shape for auth import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fetchy",
-  "version": "1.5.82",
+  "version": "1.5.88",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fetchy",
-      "version": "1.5.82",
+      "version": "1.5.88",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.4",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -393,9 +393,9 @@ export interface PostmanVariable {
 
 export interface PostmanAuth {
   type: string;
-  basic?: Array<{ key: string; value: string }> | Record<string, string>;
-  bearer?: Array<{ key: string; value: string }> | Record<string, string>;
-  apikey?: Array<{ key: string; value: string }> | Record<string, string>;
+  basic?: Array<{ key: string; value: string }> | { key: string; value: string; type?: string } | Record<string, string>;
+  bearer?: Array<{ key: string; value: string }> | { key: string; value: string; type?: string } | Record<string, string>;
+  apikey?: Array<{ key: string; value: string }> | { key: string; value: string; type?: string } | Record<string, string>;
 }
 
 // OpenAPI Document for storage

--- a/src/utils/postman.ts
+++ b/src/utils/postman.ts
@@ -31,9 +31,13 @@ const parsePostmanUrl = (url: PostmanUrl | string): { url: string; params: KeyVa
   return { url: url.raw, params };
 };
 
-// Helper to get value from Postman auth field (handles both array and object formats)
+// Helper to get value from Postman auth field (handles array, single key/value object, and plain map formats)
 const getPostmanAuthValue = (
-  authField: Array<{ key: string; value: string }> | Record<string, string> | undefined,
+  authField:
+    | Array<{ key: string; value: string }>
+    | { key: string; value: string; type?: string }
+    | Record<string, string>
+    | undefined,
   key: string
 ): string => {
   if (!authField) return '';
@@ -43,8 +47,14 @@ const getPostmanAuthValue = (
     return authField.find(b => b.key === key)?.value || '';
   }
 
-  // If it is an object, access directly
   if (typeof authField === 'object') {
+    // Single key/value pair object, e.g. { key: "token", value: "{{access_token}}", type: "string" }
+    if ('key' in authField && 'value' in authField) {
+      const single = authField as { key: string; value: string };
+      return single.key === key ? single.value ?? '' : '';
+    }
+
+    // Plain map object, e.g. { token: "<value>" }
     return (authField as Record<string, string>)[key] || '';
   }
 


### PR DESCRIPTION
Some Postman collection exports represent bearer/basic/apikey auth fields as a single {key, value, type} object instead of an array of {key, value} pairs or a plain map. The importer only handled the array and plain-map shapes, so tokens like {{access_token}} for bearer auth were silently dropped as empty strings.

getPostmanAuthValue() now also detects the single key/value object shape and extracts the value when the key matches.