### PR TITLE
fix(postman): handle missing optional fields in Postman import

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -356,7 +356,7 @@ export interface PostmanRequest {
   method: string;
   header?: PostmanHeader[];
   body?: PostmanBody;
-  url: PostmanUrl | string;
+  url?: PostmanUrl | string;
   auth?: PostmanAuth;
 }
 
@@ -380,7 +380,7 @@ export interface PostmanBody {
 }
 
 export interface PostmanUrl {
-  raw: string;
+  raw?: string;
   protocol?: string;
   host?: string[];
   path?: string[];

--- a/src/utils/postman.ts
+++ b/src/utils/postman.ts
@@ -15,20 +15,36 @@ import { convertMustacheVarsDeep } from './helpers';
 import { convertPostmanScript } from './scriptConverter';
 
 // Helper to parse Postman URL
-const parsePostmanUrl = (url: PostmanUrl | string): { url: string; params: KeyValue[] } => {
+const parsePostmanUrl = (url: PostmanUrl | string | undefined | null): { url: string; params: KeyValue[] } => {
+  if (!url) {
+    return { url: '', params: [] };
+  }
+
   if (typeof url === 'string') {
     return { url, params: [] };
   }
 
   const params: KeyValue[] = (url.query || []).map(q => ({
     id: uuidv4(),
-    key: q.key,
-    value: q.value,
+    key: q.key || '',
+    value: q.value || '',
     enabled: !q.disabled,
     description: q.description,
   }));
 
-  return { url: url.raw, params };
+  // "raw" is normally always present in Postman exports, but reconstruct a
+  // best-effort URL from the remaining optional pieces if it is missing.
+  const rawUrl = url.raw || buildUrlFromParts(url);
+
+  return { url: rawUrl, params };
+};
+
+// Reconstruct a URL string from protocol/host/path when "raw" is absent
+const buildUrlFromParts = (url: PostmanUrl): string => {
+  const protocol = url.protocol ? `${url.protocol}://` : '';
+  const host = (url.host || []).join('.');
+  const path = (url.path || []).join('/');
+  return `${protocol}${host}${path ? `/${path}` : ''}`;
 };
 
 // Helper to get value from Postman auth field (handles array, single key/value object, and plain map formats)
@@ -96,8 +112,8 @@ const convertPostmanRequest = (item: PostmanItem): ApiRequest | null => {
 
   const headers: KeyValue[] = (request.header || []).map(h => ({
     id: uuidv4(),
-    key: h.key,
-    value: h.value,
+    key: h.key || '',
+    value: h.value || '',
     enabled: !h.disabled,
     description: h.description,
   }));
@@ -117,8 +133,8 @@ const convertPostmanRequest = (item: PostmanItem): ApiRequest | null => {
           type: 'x-www-form-urlencoded',
           urlencoded: (request.body.urlencoded || []).map(u => ({
             id: uuidv4(),
-            key: u.key,
-            value: u.value,
+            key: u.key || '',
+            value: u.value || '',
             enabled: !u.disabled,
             description: u.description,
           })),
@@ -129,8 +145,8 @@ const convertPostmanRequest = (item: PostmanItem): ApiRequest | null => {
           type: 'form-data',
           formData: (request.body.formdata || []).map(f => ({
             id: uuidv4(),
-            key: f.key,
-            value: f.value,
+            key: f.key || '',
+            value: f.value || '',
             enabled: !f.disabled,
             description: f.description,
           })),
@@ -160,7 +176,7 @@ const convertPostmanRequest = (item: PostmanItem): ApiRequest | null => {
 
   return {
     id: uuidv4(),
-    name: item.name,
+    name: item.name || 'Untitled Request',
     method: (request.method?.toUpperCase() || 'GET') as HttpMethod,
     url,
     headers,
@@ -183,7 +199,7 @@ const convertPostmanItems = (items: PostmanItem[]): { folders: RequestFolder[]; 
       const subResult = convertPostmanItems(item.item);
       folders.push({
         id: uuidv4(),
-        name: item.name,
+        name: item.name || 'Untitled Folder',
         description: item.description,
         folders: subResult.folders,
         requests: subResult.requests,
@@ -225,20 +241,20 @@ export const importPostmanCollection = (content: string): Collection | null => {
       throw new Error('Invalid Postman collection format: missing "item" field');
     }
 
-    const { folders, requests } = convertPostmanItems(postman.item);
+    const { folders, requests } = convertPostmanItems(postman.item || []);
 
     const variables: KeyValue[] = (postman.variable || []).map(v => ({
       id: uuidv4(),
-      key: v.key,
-      value: v.value, // For backward compatibility
-      initialValue: v.value, // Set imported value as initial
+      key: v.key || '',
+      value: v.value || '', // For backward compatibility
+      initialValue: v.value || '', // Set imported value as initial
       currentValue: '', // Start with empty current value
       enabled: !v.disabled,
     }));
 
     return convertMustacheVarsDeep({
       id: uuidv4(),
-      name: postman.info.name,
+      name: postman.info.name || 'Imported Postman Collection',
       description: postman.info.description,
       folders,
       requests,

--- a/test/postman.test.ts
+++ b/test/postman.test.ts
@@ -750,3 +750,238 @@ describe('exportToPostman', () => {
     expect(parsed.info.schema).toContain('schema.getpostman.com');
   });
 });
+
+// --------------------------------------------------------------------------
+// GH-94: importPostmanCollection – missing optional fields
+// --------------------------------------------------------------------------
+
+describe('importPostmanCollection – GH-94 missing optional fields', () => {
+  it('should default params to an empty array when url.query is omitted', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'No Query Test', schema: '' },
+        item: [
+          {
+            name: 'No Query Request',
+            request: {
+              method: 'GET',
+              url: { raw: 'https://api.example.com/users' },
+            },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    const req = collection!.requests[0];
+    expect(req.url).toBe('https://api.example.com/users');
+    expect(req.params).toEqual([]);
+  });
+
+  it('should default headers to an empty array when request.header is omitted', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'No Header Test', schema: '' },
+        item: [
+          {
+            name: 'No Header Request',
+            request: {
+              method: 'GET',
+              url: { raw: 'https://api.example.com' },
+            },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.requests[0].headers).toEqual([]);
+  });
+
+  it('should default body to type "none" when request.body is omitted', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'No Body Test', schema: '' },
+        item: [
+          {
+            name: 'No Body Request',
+            request: {
+              method: 'GET',
+              url: { raw: 'https://api.example.com' },
+            },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.requests[0].body.type).toBe('none');
+  });
+
+  it('should reconstruct the URL from protocol/host/path when url.raw is absent', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'No Raw Url Test', schema: '' },
+        item: [
+          {
+            name: 'No Raw Request',
+            request: {
+              method: 'GET',
+              url: {
+                protocol: 'https',
+                host: ['api', 'example', 'com'],
+                path: ['v1', 'users'],
+              },
+            },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    const req = collection!.requests[0];
+    expect(req.url).toBe('https://api.example.com/v1/users');
+    expect(req.params).toEqual([]);
+  });
+
+  it('should reconstruct a host-only URL when protocol and path are both absent', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'Host Only Test', schema: '' },
+        item: [
+          {
+            name: 'Host Only Request',
+            request: {
+              method: 'GET',
+              url: { host: ['api', 'example', 'com'] },
+            },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.requests[0].url).toBe('api.example.com');
+  });
+
+  it('should default url to an empty string when request.url is entirely missing', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'No Url Test', schema: '' },
+        item: [
+          {
+            name: 'No Url Request',
+            request: {
+              method: 'GET',
+            },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    const req = collection!.requests[0];
+    expect(req.url).toBe('');
+    expect(req.params).toEqual([]);
+  });
+
+  it('should default url to an empty string when request.url is null', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'Null Url Test', schema: '' },
+        item: [
+          {
+            name: 'Null Url Request',
+            request: {
+              method: 'GET',
+              url: null,
+            },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.requests[0].url).toBe('');
+  });
+
+  it('should default a request item name to "Untitled Request" when name is missing', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'No Item Name Test', schema: '' },
+        item: [
+          {
+            request: {
+              method: 'GET',
+              url: { raw: 'https://api.example.com' },
+            },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.requests[0].name).toBe('Untitled Request');
+  });
+
+  it('should default a folder name to "Untitled Folder" when name is missing', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'No Folder Name Test', schema: '' },
+        item: [
+          {
+            item: [
+              {
+                name: 'Nested Request',
+                request: {
+                  method: 'GET',
+                  url: { raw: 'https://api.example.com' },
+                },
+              },
+            ],
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.folders[0].name).toBe('Untitled Folder');
+    expect(collection!.folders[0].requests[0].name).toBe('Nested Request');
+  });
+
+  it('should default the collection name when info.name is missing', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { schema: '' },
+        item: [],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.name).toBe('Imported Postman Collection');
+  });
+
+  it('should default collection variables to an empty array when the "variable" field is missing', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'No Variables Test', schema: '' },
+        item: [],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.variables).toEqual([]);
+  });
+
+  it('should import a fully minimal collection with every optional field omitted', () => {
+    const collection = importPostmanCollection(
+      JSON.stringify({
+        info: { name: 'Minimal Collection', schema: '' },
+        item: [
+          {
+            name: 'Bare Request',
+            request: { method: 'GET' },
+          },
+        ],
+      })
+    );
+    expect(collection).not.toBeNull();
+    expect(collection!.name).toBe('Minimal Collection');
+    expect(collection!.variables).toEqual([]);
+    expect(collection!.requests).toHaveLength(1);
+    const req = collection!.requests[0];
+    expect(req.url).toBe('');
+    expect(req.params).toEqual([]);
+    expect(req.headers).toEqual([]);
+    expect(req.body.type).toBe('none');
+  });
+});


### PR DESCRIPTION
Resolves #94. Fixes Postman importer to handle missing optional fields like query, header, body, and url.raw. All 61 postman tests passing, no regressions.

## 🤖 AI Review

**Task:** GH-94 — Fetchy fails to import Postman collections with missing optional fields (e.g., query)
**Reviewed commit:** 1626e1b · **Branch:** feat/gh-94-postman-optional-fields
**Verdict:** ✅ Approve — no blocking issues found

> This is an automated baseline review by Metis (Pantheon). It is advisory only and does not replace human approval.

### Summary
Fixes a crash/`undefined`-URL bug in the Postman importer (`src/utils/postman.ts`) where `parsePostmanUrl` assumed `request.url` and `url.raw` were always present. The fix adds null-safety for a missing/null `url`, introduces a `buildUrlFromParts` helper to reconstruct a best-effort URL from `protocol`/`host`/`path` when `raw` is absent, and adds `|| ''`/`|| []` fallbacks for query, header, urlencoded, form-data, item/folder/collection names, and collection variables. `PostmanRequest.url` and `PostmanUrl.raw` are loosened to optional in `src/types/index.ts` to match the new runtime contract. 12 new targeted tests were added to `test/postman.test.ts`.

### Correctness
- `parsePostmanUrl` now correctly short-circuits on `null`/`undefined` url (`{ url: '', params: [] }`), fixing the reported crash.
- `buildUrlFromParts` produces sensible reconstructions for protocol+host+path and host-only cases; joining `host` with `.` and `path` with `/` matches Postman's own URL-object convention.
- Blast-radius check (`codegraph impact "parsePostmanUrl"`) confirms the change is contained to `parsePostmanUrl`, `convertPostmanRequest`, and `convertPostmanItems` in the same file — no cross-module fallout.
- The `PostmanUrl`/`PostmanRequest.url` type change was also checked against `exportToPostman`, which always constructs `url: { raw: request.url }` from a definite string — the export path is unaffected by the loosened type.
- `postman.item` and `postman.info` remain required/validated (existing behavior, documented as intentionally out of scope in key-decisions.md) — consistent with the issue's proposed fix, which scoped only query/header/body-style optional fields.
- Minor: in `importPostmanCollection`, `postman.item` is validated with an explicit throw if missing, then still passed as `postman.item || []` into `convertPostmanItems` — harmless but redundant since the throw already guarantees it's defined at that point.

### Code Quality
- Changes are small, localized, and follow the existing file's style (arrow-function helpers, `KeyValue` mapping pattern).
- `buildUrlFromParts` is a clean single-purpose extraction with a clarifying comment on why `raw` might be absent.
- Fallback strings (`'Untitled Request'`, `'Untitled Folder'`, `'Imported Postman Collection'`) are reasonable, user-facing defaults consistent with a defensive-import philosophy.
- No new dependencies, no dead code, no leftover debug statements.

### Security (OWASP Top 10)
- No new attack surface introduced — this is pure client-side JSON parsing/transformation of user-supplied import data, already covered by the existing `try/catch` in `importPostmanCollection` (A04:2021 Insecure Design mitigated by fail-safe error handling that re-throws with context rather than silently corrupting state).
- No use of `eval`, dynamic `Function`, or unsanitized HTML/DOM injection in the diff.
- String reconstruction in `buildUrlFromParts` is simple concatenation of trusted-shape array elements (already typed as `string[]`) — no injection vector beyond what already existed for `raw`.
- No secrets, tokens, or credentials touched by this change.

### Tests
- 12 new tests in `test/postman.test.ts` directly target the reported gap: missing `url.query`, missing `request.header`, missing `request.body`, `url.raw` reconstruction (protocol+host+path and host-only), fully missing/`null` `request.url`, missing item/folder names, missing `info.name`, missing collection `variable`, and a fully-minimal collection combining all of the above.
- Suite results reported by Themis: 61/61 in `postman.test.ts`, 2337/2346 full suite (9 pre-existing, unrelated `HistoryPanel.test.tsx` failures, verified via `git status` to be untouched by this change).
- Coverage maps well to the issue's reproduction steps and the `buildUrlFromParts` branch logic (protocol+host+path, host-only, and raw-present paths are each independently tested).

### Risks & Suggestions
1. **Minor (readability)** — `postman.item || []` in `importPostmanCollection` (line ~245) is unreachable given the preceding `if (!postman.item) throw ...` guard. Consider removing the fallback or converting the guard to also cover empty-array semantics for clarity, but this is purely cosmetic and not a defect.
2. **Minor (edge case, out of current scope)** — `buildUrlFromParts` does not URL-encode `path` segments before joining; if a Postman export ever contains path segments with special characters and no `raw`, the reconstructed URL could be malformed. Low real-world likelihood since Postman almost always emits `raw`, and this mirrors the existing (pre-change) trust level for `raw` itself.
3. **Low priority (types)** — Since `PostmanUrl.raw` is now optional, any future direct consumer of `url.raw` elsewhere in the codebase should double-check for `undefined` handling; current blast-radius analysis shows no such consumer today, so no action needed now.

**Positives:** Root cause was correctly diagnosed (initial investigation confirmed most fields were already null-safe; the real gap was isolated precisely to `parsePostmanUrl`). Fix is minimal, well-tested, and scoped tightly to the reported defect without speculative refactoring.
