### PR TITLE
feat: add HTTP QUERY method support

### DIFF
--- a/electron/ipc/validate.js
+++ b/electron/ipc/validate.js
@@ -141,8 +141,8 @@ function requireDirectoryPath(value, name) {
  * Validate an HTTP method.
  */
 const ALLOWED_METHODS = new Set([
-  'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS',
-  'get', 'post', 'put', 'patch', 'delete', 'head', 'options',
+  'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY',
+  'get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'query',
 ]);
 
 function requireHttpMethod(value, name) {

--- a/scripts/convert-hoppscotch.js
+++ b/scripts/convert-hoppscotch.js
@@ -65,7 +65,7 @@ function convertHoppscotchScript(script) {
 // ---------------------------------------------------------------------------
 // Clean a single request — keep Hoppscotch field names, strip noise
 // ---------------------------------------------------------------------------
-const VALID_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+const VALID_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY'];
 
 function cleanRequest(req) {
   const method = (req.method || 'GET').toUpperCase();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -103,7 +103,7 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
 
   // History filter and sort states
   const [historySearch, setHistorySearch] = useState('');
-  const [historyFilterMethod, setHistoryFilterMethod] = useState<'all' | 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'>('all');
+  const [historyFilterMethod, setHistoryFilterMethod] = useState<FilterMethod>('all');
   const [historySortOption, setHistorySortOption] = useState<'date-desc' | 'date-asc' | 'name-asc' | 'name-desc' | 'method'>('date-desc');
   const [showHistoryFilterMenu, setShowHistoryFilterMenu] = useState(false);
   const [apiFilterFormat, setApiFilterFormat] = useState<'all' | 'yaml' | 'json'>('all');
@@ -898,7 +898,7 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
                   <div className="fixed inset-0 z-40" onClick={() => setShowFilterMenu(false)} />
                   <div className="absolute right-0 top-full mt-1 z-50 bg-fetchy-dropdown border border-fetchy-border rounded-lg shadow-xl py-2 min-w-[180px]">
                     <div className="px-3 py-1 text-xs font-medium text-fetchy-text-muted uppercase">Filter by Method</div>
-                    {(['all', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const).map((method) => (
+                    {(['all', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'] as const).map((method) => (
                       <button
                         key={method}
                         className={`w-full px-3 py-1.5 text-left text-sm hover:bg-fetchy-border flex items-center gap-2 ${filterMethod === method ? 'text-fetchy-accent' : ''}`}
@@ -1012,7 +1012,7 @@ export default function Sidebar({ onImport, onHistoryItemClick }: SidebarProps) 
                   <div className="fixed inset-0 z-40" onClick={() => setShowHistoryFilterMenu(false)} />
                   <div className="absolute right-0 top-full mt-1 z-50 bg-fetchy-dropdown border border-fetchy-border rounded-lg shadow-xl py-2 min-w-[180px]">
                     <div className="px-3 py-1 text-xs font-medium text-fetchy-text-muted uppercase">Filter by Method</div>
-                    {(['all', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const).map((method) => (
+                    {(['all', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'] as const).map((method) => (
                       <button
                         key={method}
                         className={`w-full px-3 py-1.5 text-left text-sm hover:bg-fetchy-border flex items-center gap-2 ${historyFilterMethod === method ? 'text-fetchy-accent' : ''}`}

--- a/src/components/openapi/OpenApiEditor.tsx
+++ b/src/components/openapi/OpenApiEditor.tsx
@@ -367,7 +367,7 @@ export default function OpenApiEditor({ documentId }: OpenApiEditorProps) {
     const grouped = new Map<string, Array<{ path: string; method: string; operation: PathOperation; pathItem: Record<string, unknown> }>>();
 
     // Valid HTTP methods in OpenAPI
-    const httpMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
+    const httpMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace', 'query']);
 
     for (const [path, methods] of Object.entries(parsedSpec.paths)) {
       for (const [method, operation] of Object.entries(methods)) {

--- a/src/components/openapi/constants.ts
+++ b/src/components/openapi/constants.ts
@@ -384,5 +384,6 @@ export const METHOD_COLORS: Record<string, string> = {
   delete: 'bg-red-500/20 text-red-400 border-red-500/30',
   head: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
   options: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
+  query: 'bg-teal-500/20 text-teal-400 border-teal-500/30',
 };
 

--- a/src/components/request/UrlBar.tsx
+++ b/src/components/request/UrlBar.tsx
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import VariableInput from '../VariableInput';
 import Tooltip from '../Tooltip';
 
-const HTTP_METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+const HTTP_METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY'];
 
 const CODE_LANGUAGES = [
   { id: 'curl', label: 'cURL', icon: '⚡' },

--- a/src/components/sidebar/HistoryPanel.tsx
+++ b/src/components/sidebar/HistoryPanel.tsx
@@ -2,11 +2,12 @@ import { Clock } from 'lucide-react';
 import { useAppStore } from '../../store/appStore';
 import { RequestHistoryItem } from '../../types';
 import { getMethodBgColor } from '../../utils/helpers';
+import type { FilterMethod } from './types';
 
 interface HistoryPanelProps {
   onHistoryItemClick?: (item: RequestHistoryItem) => void;
   search: string;
-  filterMethod: 'all' | 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  filterMethod: FilterMethod;
   sortOption: 'date-desc' | 'date-asc' | 'name-asc' | 'name-desc' | 'method';
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -455,6 +455,19 @@ body.black-theme {
     @apply bg-pink-600/20 text-pink-700;
   }
 
+  .method-query {
+    @apply bg-teal-500/20 text-teal-400;
+  }
+  body.light-theme .method-query {
+    background-color: rgba(0, 191, 165, 0.15);
+    color: #00bfa5;
+  }
+  body.ocean-theme .method-query,
+  body.earth-theme .method-query,
+  body.candy-theme .method-query {
+    @apply bg-teal-600/20 text-teal-700;
+  }
+
   /* AI Feature Colors — uses CSS variable so all themes (including custom) are respected */
   .ai-text {
     color: var(--ai-color);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 // Type definitions for the REST Client Application
 
-export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'QUERY';
 
 export type AppMode = 'rest' | 'graphql' | 'grpc' | 'websocket' | 'mqtt' | 'socketio' | 'sse';
 

--- a/src/utils/aiImport.ts
+++ b/src/utils/aiImport.ts
@@ -27,7 +27,7 @@ const COLLECTION_SCHEMA = `{
   "requests": [
     {
       "name": "string — descriptive request name",
-      "method": "GET | POST | PUT | PATCH | DELETE | HEAD | OPTIONS",
+      "method": "GET | POST | PUT | PATCH | DELETE | HEAD | OPTIONS | QUERY",
       "url": "string — full URL with protocol",
       "headers": [
         { "key": "string", "value": "string", "enabled": true, "description": "" }
@@ -77,7 +77,7 @@ const ENVIRONMENT_SCHEMA = `{
 
 const REQUEST_SCHEMA = `{
   "name": "string — descriptive request name",
-  "method": "GET | POST | PUT | PATCH | DELETE | HEAD | OPTIONS",
+  "method": "GET | POST | PUT | PATCH | DELETE | HEAD | OPTIONS | QUERY",
   "url": "string — full URL with protocol",
   "headers": [
     { "key": "string", "value": "string", "enabled": true, "description": "" }

--- a/src/utils/aiProvider.ts
+++ b/src/utils/aiProvider.ts
@@ -104,7 +104,7 @@ export function buildGenerateRequestPrompt(description: string): AIMessage[] {
       content: `You are an expert API developer assistant integrated into a REST client application called Fetchy.
 When the user describes an API request in natural language, generate a valid JSON object with this exact structure:
 {
-  "method": "GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS",
+  "method": "GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|QUERY",
   "url": "full URL with protocol",
   "headers": [{"key": "Content-Type", "value": "application/json", "enabled": true}],
   "params": [{"key": "param", "value": "value", "enabled": true}],

--- a/src/utils/bruno.ts
+++ b/src/utils/bruno.ts
@@ -463,7 +463,7 @@ const convertBrunoJsonRequest = (item: BrunoJsonItem): ApiRequest | null => {
   }
 
   const method = (req.method?.toUpperCase() || 'GET') as HttpMethod;
-  const validMethods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+  const validMethods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY'];
   const safeMethod = validMethods.includes(method) ? method : 'GET';
 
   const params: KeyValue[] = (req.params || []).map((p) => ({
@@ -521,7 +521,7 @@ const convertBrunoJsonItems = (
 const convertBruFileToRequest = (content: string, name?: string): ApiRequest => {
   const parsed = parseBruRequestFile(content);
   const method = (parsed.method || 'GET') as HttpMethod;
-  const validMethods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+  const validMethods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY'];
   const safeMethod = validMethods.includes(method) ? method : 'GET';
 
   // Merge query params and path params into params

--- a/src/utils/hoppscotch.ts
+++ b/src/utils/hoppscotch.ts
@@ -225,7 +225,7 @@ const convertHoppBody = (body?: HoppRESTBody): RequestBody => {
 
 const convertHoppRequest = (req: HoppRESTRequest): ApiRequest => {
   const method = (req.method?.toUpperCase() || 'GET') as HttpMethod;
-  const validMethods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+  const validMethods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY'];
   const safeMethod = validMethods.includes(method) ? method : 'GET';
 
   const headers: KeyValue[] = (req.headers || []).map((h) => ({

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -25,6 +25,7 @@ export const getMethodColor = (method: HttpMethod): string => {
     DELETE: 'text-red-400',
     HEAD: 'text-gray-400',
     OPTIONS: 'text-pink-400',
+    QUERY: 'text-teal-400',
   };
   return colors[method] || 'text-gray-400';
 };
@@ -39,6 +40,7 @@ export const getMethodBgColor = (method: HttpMethod): string => {
     DELETE: 'method-delete',
     HEAD: 'method-head',
     OPTIONS: 'method-options',
+    QUERY: 'method-query',
   };
   return colors[method] || 'method-head';
 };

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -132,7 +132,7 @@ export const importOpenAPISpec = (content: string): Collection | null => {
       if (!methods || typeof methods !== 'object') continue;
 
       for (const [method, operation] of Object.entries(methods)) {
-        if (['get', 'post', 'put', 'patch', 'delete', 'head', 'options'].includes(method.toLowerCase())) {
+        if (['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'query'].includes(method.toLowerCase())) {
           const request = convertOpenAPIOperation(path, method, operation as OpenAPIOperation, baseUrl);
 
           const tags = (operation as OpenAPIOperation).tags;

--- a/test/ai-import.test.ts
+++ b/test/ai-import.test.ts
@@ -112,6 +112,13 @@ describe('buildRequestConversionPrompt', () => {
     const msgs = buildRequestConversionPrompt('data');
     expect(msgs[0].content).toContain('Request');
   });
+
+  it('system schema lists QUERY as a supported method', () => {
+    const collectionPrompt = buildCollectionConversionPrompt('data');
+    const requestPrompt = buildRequestConversionPrompt('data');
+    expect(collectionPrompt[0].content).toContain('QUERY');
+    expect(requestPrompt[0].content).toContain('QUERY');
+  });
 });
 
 // ─── aiConvertCollection ──────────────────────────────────────────────────────

--- a/test/ai-provider.test.ts
+++ b/test/ai-provider.test.ts
@@ -155,6 +155,11 @@ describe('buildGenerateRequestPrompt', () => {
     const msgs = buildGenerateRequestPrompt('test');
     expect(msgs[0].content).toContain('JSON');
   });
+
+  it('system message advertises QUERY as a supported method', () => {
+    const msgs = buildGenerateRequestPrompt('send a query request');
+    expect(msgs[0].content).toContain('QUERY');
+  });
 });
 
 // ─── buildGenerateScriptPrompt ────────────────────────────────────────────────

--- a/test/appStore.test.ts
+++ b/test/appStore.test.ts
@@ -309,6 +309,28 @@ describe('appStore – history', () => {
     expect(useAppStore.getState().history).toHaveLength(1);
   });
 
+  it('stores QUERY requests in history without aliasing the method', () => {
+    const { addToHistory } = useAppStore.getState();
+    addToHistory({
+      request: {
+        id: 'query-history-request',
+        name: 'Query History',
+        method: 'QUERY',
+        url: 'https://api.example.com/query',
+        headers: [{ id: 'h1', key: 'Content-Type', value: 'application/json', enabled: true }],
+        params: [],
+        body: { type: 'json', raw: '{"filter":"active"}' },
+        auth: { type: 'none' },
+      },
+      response: { status: 200, statusText: 'OK', headers: {}, body: '{}', time: 1, size: 2 },
+    });
+
+    const historyRequest = useAppStore.getState().history[0].request;
+    expect(historyRequest.method).toBe('QUERY');
+    expect(historyRequest.body).toEqual({ type: 'json', raw: '{"filter":"active"}' });
+    expect(historyRequest.headers[0]).toMatchObject({ key: 'Content-Type', value: 'application/json' });
+  });
+
   it('clearHistory removes all entries', () => {
     const { addToHistory, clearHistory } = useAppStore.getState();
     addToHistory({ method: 'GET', url: 'https://api.dev', status: 200 } as any);
@@ -409,6 +431,32 @@ describe('appStore – exportFullStorage / importFullStorage', () => {
       activeEnvironmentId: null,
     });
     expect(useAppStore.getState().collections.some(c => c.name === 'Imported Col')).toBe(true);
+  });
+
+  it('preserves QUERY request fields through full storage export/import', () => {
+    const { addCollection, addRequest, exportFullStorage, importFullStorage } = useAppStore.getState();
+    const collection = addCollection('Query Collection');
+    addRequest(collection.id, null, {
+      name: 'Query Request',
+      method: 'QUERY',
+      url: 'https://api.example.com/query',
+      headers: [{ id: 'h1', key: 'X-Query', value: 'enabled', enabled: true }],
+      params: [{ id: 'p1', key: 'filter', value: 'active', enabled: true }],
+      body: { type: 'json', raw: '{"filter":"active"}' },
+    });
+
+    const snapshot = exportFullStorage();
+    importFullStorage(snapshot);
+
+    const restored = useAppStore.getState().collections
+      .find(c => c.name === 'Query Collection')!.requests[0];
+    expect(restored).toMatchObject({
+      method: 'QUERY',
+      url: 'https://api.example.com/query',
+      headers: [expect.objectContaining({ key: 'X-Query', value: 'enabled', enabled: true })],
+      params: [expect.objectContaining({ key: 'filter', value: 'active', enabled: true })],
+      body: { type: 'json', raw: '{"filter":"active"}' },
+    });
   });
 });
 

--- a/test/bruno.test.ts
+++ b/test/bruno.test.ts
@@ -785,3 +785,71 @@ describe('importBrunoEnvironment — additional edge cases', () => {
     expect(envs[0].name).toBe('Bruno Environment');
   });
 });
+
+describe('importBrunoCollection — QUERY method support', () => {
+  it('preserves QUERY method, headers, params, and JSON body from Bruno JSON', () => {
+    const json = {
+      name: 'Bruno Query Collection',
+      items: [{
+        type: 'http-request',
+        name: 'Query Request',
+        request: {
+          method: 'QUERY',
+          url: 'https://api.example.com/query',
+          headers: { 'Content-Type': 'application/json', 'X-Query': 'enabled' },
+          params: [{ name: 'filter', value: 'active', enabled: true }],
+          body: { mode: 'json', json: '{"filter":"active"}' },
+        },
+      }],
+    };
+
+    const request = importBrunoCollection(JSON.stringify(json)).requests[0];
+
+    expect(request.method).toBe('QUERY');
+    expect(request.url).toBe('https://api.example.com/query');
+    expect(request.headers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'Content-Type', value: 'application/json', enabled: true }),
+      expect.objectContaining({ key: 'X-Query', value: 'enabled', enabled: true }),
+    ]));
+    expect(request.params).toEqual([
+      expect.objectContaining({ key: 'filter', value: 'active', enabled: true }),
+    ]);
+    expect(request.body).toEqual({ type: 'json', raw: '{"filter":"active"}' });
+  });
+
+  it('parses QUERY from a Bruno http block without confusing the query params block', () => {
+    const bru = `meta {
+  name: Query HTTP Block
+  type: http
+}
+
+http {
+  url: https://api.example.com/query
+  method: QUERY
+}
+
+query {
+  filter: active
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {"filter":"active"}
+}
+`;
+
+    const request = importBrunoCollection(bru).requests[0];
+
+    expect(request.method).toBe('QUERY');
+    expect(request.params).toEqual([
+      expect.objectContaining({ key: 'filter', value: 'active', enabled: true }),
+    ]);
+    expect(request.headers).toEqual([
+      expect.objectContaining({ key: 'Content-Type', value: 'application/json', enabled: true }),
+    ]);
+    expect(request.body).toEqual({ type: 'json', raw: '{"filter":"active"}' });
+  });
+});

--- a/test/components/Sidebar.test.tsx
+++ b/test/components/Sidebar.test.tsx
@@ -71,7 +71,7 @@ vi.mock('../../src/components/sidebar/SortableRequestItem', () => ({
 }));
 
 vi.mock('../../src/components/sidebar/HistoryPanel', () => ({
-  default: ({ onHistoryItemClick }: any) => <div data-testid="history-panel">History Panel</div>,
+  default: ({ filterMethod }: any) => <div data-testid="history-panel" data-filter-method={filterMethod}>History Panel</div>,
 }));
 
 vi.mock('../../src/components/sidebar/ApiDocsPanel', () => ({
@@ -156,6 +156,8 @@ function mockStores(overrides: Record<string, any> = {}) {
     tabs: [],
     activeTabId: null,
     openApiDocuments: [],
+    history: [],
+    clearHistory: vi.fn(),
     addCollection,
     updateCollection,
     toggleCollectionExpanded,
@@ -171,7 +173,9 @@ function mockStores(overrides: Record<string, any> = {}) {
     moveFolder,
     ...overrides,
   };
-  vi.mocked(useAppStore).mockReturnValue(defaultState as any);
+  (useAppStore as any).mockImplementation((selector?: (state: typeof defaultState) => unknown) => (
+    selector ? selector(defaultState) : defaultState
+  ));
   (useAppStore as any).getState = vi.fn(() => defaultState);
 }
 
@@ -293,6 +297,7 @@ describe('Sidebar', () => {
     fireEvent.click(filterBtn!);
     expect(screen.getByText('Filter by Method')).toBeDefined();
     expect(screen.getByText('All Methods')).toBeDefined();
+    expect(screen.getByText('QUERY')).toBeDefined();
   });
 
   // 8. Sort option changes
@@ -594,20 +599,43 @@ describe('Sidebar', () => {
     expect(toggleCollectionExpanded).toHaveBeenCalledWith('col-1');
   });
 
-  it('filters requests by HTTP method', () => {
+  it('filters requests by QUERY method', () => {
     const req1 = makeRequest({ id: 'r1', name: 'Get Users', method: 'GET' });
-    const req2 = makeRequest({ id: 'r2', name: 'Create Post', method: 'POST' });
+    const req2 = makeRequest({ id: 'r2', name: 'Query Users', method: 'QUERY' });
     const col = makeCollection({ requests: [req1, req2] });
     mockStores({ collections: [col] });
     render(<Sidebar onImport={onImport} />);
     const filterBtn = screen.getAllByRole('button').find(b => b.querySelector('[data-testid="icon-filter"]'));
     fireEvent.click(filterBtn!);
     // Use getAllByText to find the filter menu option (a button with role='button' in the dropdown)
-    const getOptions = screen.getAllByText('GET');
-    const filterOption = getOptions.find(el => el.tagName === 'BUTTON');
+    const queryOptions = screen.getAllByText('QUERY');
+    const filterOption = queryOptions.find(el => el.tagName === 'BUTTON');
     fireEvent.click(filterOption!);
-    expect(screen.getByText('Get Users')).toBeDefined();
-    expect(screen.queryByText('Create Post')).toBeNull();
+    expect(screen.getByText('Query Users')).toBeDefined();
+    expect(screen.queryByText('Get Users')).toBeNull();
+  });
+
+  it('offers and applies the QUERY filter in request history', () => {
+    mockStores({
+      history: [{
+        id: 'history-query',
+        request: makeRequest({ method: 'QUERY' }),
+        timestamp: Date.now(),
+      }],
+    });
+    render(<Sidebar onImport={onImport} onHistoryItemClick={onHistoryItemClick} />);
+
+    const historyBtn = screen.getAllByRole('button').find(b => b.querySelector('[data-testid="icon-clock"]'));
+    fireEvent.click(historyBtn!);
+
+    const filterBtn = screen.getAllByRole('button').find(b => b.querySelector('[data-testid="icon-filter"]'));
+    fireEvent.click(filterBtn!);
+
+    const queryOptions = screen.getAllByText('QUERY');
+    const filterOption = queryOptions.find(el => el.tagName === 'BUTTON');
+    fireEvent.click(filterOption!);
+
+    expect(screen.getByTestId('history-panel').getAttribute('data-filter-method')).toBe('QUERY');
   });
 
   it('clears all collection filters', () => {

--- a/test/components/UrlBar.test.tsx
+++ b/test/components/UrlBar.test.tsx
@@ -93,6 +93,7 @@ describe('UrlBar', () => {
     expect(options).toContain('PATCH');
     expect(options).toContain('HEAD');
     expect(options).toContain('OPTIONS');
+    expect(options).toContain('QUERY');
   });
 
   it('calls onChange with new method when method select changes', () => {
@@ -101,6 +102,14 @@ describe('UrlBar', () => {
     render(<UrlBar {...defaultProps} onChange={onChange} />);
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'POST' } });
     expect(onChange).toHaveBeenCalledWith({ method: 'POST' });
+  });
+
+  it('calls onChange with QUERY when the method select changes', () => {
+    const onChange = vi.fn();
+    vi.mocked(useAppStore).mockReturnValue(baseStore() as never);
+    render(<UrlBar {...defaultProps} onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'QUERY' } });
+    expect(onChange).toHaveBeenCalledWith({ method: 'QUERY' });
   });
 
   it('renders URL input with the provided URL', () => {

--- a/test/components/openapi/OpenApiEditor.test.tsx
+++ b/test/components/openapi/OpenApiEditor.test.tsx
@@ -668,6 +668,29 @@ describe('OpenApiEditor', () => {
       expect(putTexts.length).toBeGreaterThanOrEqual(1);
     });
 
+    it('renders QUERY operations from an API spec with the QUERY method style', () => {
+      const querySpec = {
+        ...fullSpec,
+        paths: {
+          ...fullSpec.paths,
+          '/search': {
+            query: {
+              tags: ['users'],
+              summary: 'Search users with QUERY',
+              responses: { '200': { description: 'Successful response' } },
+            },
+          },
+        },
+      };
+
+      mockStores({ spec: querySpec });
+      render(<OpenApiEditor />);
+
+      const queryBadge = screen.getByText('query');
+      expect(queryBadge.className).toContain('bg-teal-500/20');
+      expect(screen.getByText('Search users with QUERY')).toBeDefined();
+    });
+
     it('shows endpoint paths', () => {
       mockStores();
       render(<OpenApiEditor />);

--- a/test/components/sidebar/HistoryPanel.test.tsx
+++ b/test/components/sidebar/HistoryPanel.test.tsx
@@ -132,6 +132,24 @@ describe('HistoryPanel – with history', () => {
     fireEvent.click(itemEl);
     expect(onClick).toHaveBeenCalledWith(item);
   });
+
+  it('filters history entries by QUERY method', () => {
+    const getItem = makeHistoryItem();
+    const queryItem = makeHistoryItem({
+      id: 'hist-query',
+      request: {
+        ...getItem.request,
+        name: 'Query Users',
+        method: 'QUERY',
+      },
+    });
+
+    setupStore([getItem, queryItem]);
+    render(<HistoryPanel {...defaultProps} filterMethod="QUERY" />);
+
+    expect(screen.getByText('Query Users')).toBeTruthy();
+    expect(screen.queryByText('Get Users')).toBeNull();
+  });
 });
 
 // ─── Time formatting ──────────────────────────────────────────────────────────

--- a/test/curl-parser.test.ts
+++ b/test/curl-parser.test.ts
@@ -119,6 +119,21 @@ describe('parseCurlCommand — methods', () => {
     expect(result!.method).toBe('PATCH');
   });
 
+  it('parses QUERY with headers and a JSON body without aliasing the method', () => {
+    const result = parseCurlCommand(
+      `curl --request QUERY -H 'Content-Type: application/json' -H 'X-Query: enabled' -d '{"filter":"active"}' https://api.example.com/query`
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.method).toBe('QUERY');
+    expect(result!.headers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'Content-Type', value: 'application/json', enabled: true }),
+      expect.objectContaining({ key: 'X-Query', value: 'enabled', enabled: true }),
+    ]));
+    expect(result!.body.type).toBe('json');
+    expect(JSON.parse(result!.body.raw!)).toEqual({ filter: 'active' });
+  });
+
   it('defaults to GET when no method specified', () => {
     const result = parseCurlCommand('curl https://api.example.com');
     expect(result!.method).toBe('GET');

--- a/test/hoppscotch.test.ts
+++ b/test/hoppscotch.test.ts
@@ -2,8 +2,10 @@
  * Tests for Hoppscotch collection and environment import parsers.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { importHoppscotchCollection, importHoppscotchEnvironment } from '../src/utils/hoppscotch';
 
 const fixturesDir = join(__dirname, 'data');
@@ -523,5 +525,64 @@ describe('importHoppscotchEnvironment — additional branch coverage', () => {
     }));
     expect(result[0].variables[0].value).toBe('fromValue');
     expect(result[0].variables[0].initialValue).toBe('fromValue');
+  });
+});
+
+describe('Hoppscotch QUERY method support', () => {
+  it('imports QUERY with body, headers, and params', () => {
+    const result = importHoppscotchCollection(JSON.stringify({
+      name: 'Query Collection',
+      requests: [{
+        name: 'Query Request',
+        method: 'QUERY',
+        endpoint: 'https://api.example.com/query',
+        params: [{ key: 'filter', value: 'active', active: true }],
+        headers: [{ key: 'Content-Type', value: 'application/json', active: true }],
+        body: { contentType: 'application/json', body: '{"filter":"active"}' },
+      }],
+    }));
+
+    const request = result[0].requests[0];
+    expect(request.method).toBe('QUERY');
+    expect(request.url).toBe('https://api.example.com/query');
+    expect(request.params).toEqual([
+      expect.objectContaining({ key: 'filter', value: 'active', enabled: true }),
+    ]);
+    expect(request.headers).toEqual([
+      expect.objectContaining({ key: 'Content-Type', value: 'application/json', enabled: true }),
+    ]);
+    expect(request.body).toEqual({ type: 'json', raw: '{"filter":"active"}' });
+  });
+
+  it('keeps QUERY through the Hoppscotch conversion script', () => {
+    const workDir = mkdtempSync(join(tmpdir(), 'fetchy-hoppscotch-query-'));
+    const inputPath = join(workDir, 'input.json');
+    const outputPath = join(workDir, 'output.json');
+    const scriptPath = join(__dirname, '..', 'scripts', 'convert-hoppscotch.js');
+
+    try {
+      writeFileSync(inputPath, JSON.stringify({
+        name: 'Converted Query Collection',
+        requests: [{
+          name: 'Converted Query',
+          method: 'QUERY',
+          endpoint: 'https://api.example.com/query',
+          headers: [{ key: 'X-Query', value: 'enabled', active: true }],
+          body: { contentType: 'application/json', body: '{"filter":"active"}' },
+        }],
+      }));
+
+      execFileSync(process.execPath, [scriptPath, inputPath, outputPath], { stdio: 'ignore' });
+      const converted = JSON.parse(readFileSync(outputPath, 'utf-8'));
+      const request = converted[0].requests[0];
+
+      expect(request.method).toBe('QUERY');
+      expect(request.headers).toEqual([
+        expect.objectContaining({ key: 'X-Query', value: 'enabled', active: true }),
+      ]);
+      expect(request.body).toEqual({ contentType: 'application/json', body: '{"filter":"active"}' });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/http-utils.test.ts
+++ b/test/http-utils.test.ts
@@ -76,8 +76,12 @@ describe('getMethodColor', () => {
     expect(getMethodColor('DELETE')).toContain('red');
   });
 
+  it('returns teal for QUERY', () => {
+    expect(getMethodColor('QUERY')).toBe('text-teal-400');
+  });
+
   it('returns a color for every standard method', () => {
-    const methods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+    const methods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY'];
     methods.forEach(method => {
       expect(getMethodColor(method)).toBeTruthy();
     });
@@ -88,11 +92,15 @@ describe('getMethodColor', () => {
 
 describe('getMethodBgColor', () => {
   it('returns a CSS class for each standard method', () => {
-    const methods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+    const methods: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY'];
     methods.forEach(method => {
       const cls = getMethodBgColor(method);
       expect(cls).toMatch(/^method-/);
     });
+  });
+
+  it('returns the QUERY badge class', () => {
+    expect(getMethodBgColor('QUERY')).toBe('method-query');
   });
 });
 

--- a/test/httpClient.test.ts
+++ b/test/httpClient.test.ts
@@ -300,6 +300,35 @@ describe('executeRequest', () => {
     globalThis.fetch = originalFetch;
   });
 
+  it('sends QUERY as a real method with a JSON body, query params, and headers in browser mode', async () => {
+    const req = {
+      ...baseRequest,
+      method: 'QUERY' as const,
+      params: [{ id: '1', key: 'filter', value: 'active', enabled: true }],
+      headers: [{ id: '2', key: 'X-Request-Class', value: 'query', enabled: true }],
+      body: { type: 'json' as const, raw: '{"filter":"active"}' },
+    };
+
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ status: 200, statusText: 'OK', headers: {}, body: '', time: 0, size: 0 }),
+    });
+    globalThis.fetch = fetchMock;
+
+    await executeRequest({ request: req });
+    const callBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+    expect(callBody.method).toBe('QUERY');
+    expect(callBody.url).toBe('https://api.example.com/data?filter=active');
+    expect(callBody.headers).toEqual({
+      'X-Request-Class': 'query',
+      'Content-Type': 'application/json',
+    });
+    expect(callBody.body).toBe('{"filter":"active"}');
+
+    globalThis.fetch = originalFetch;
+  });
+
   it('sets Content-Type for urlencoded body', async () => {
     const req = {
       ...baseRequest,
@@ -486,6 +515,63 @@ describe('executeRequest', () => {
       }),
     );
   });
+
+  it('sends QUERY as a real method with body and headers through Electron IPC', async () => {
+    const req = {
+      ...baseRequest,
+      method: 'QUERY' as const,
+      headers: [
+        { id: '1', key: 'Content-Type', value: 'application/query+json', enabled: true },
+        { id: '2', key: 'X-Request-Class', value: 'query', enabled: true },
+      ],
+      body: { type: 'json' as const, raw: '{"filter":"active"}' },
+    };
+    const httpRequest = vi.fn().mockResolvedValue({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      body: '{}',
+      time: 10,
+      size: 2,
+    });
+
+    (globalThis as any).window = {
+      electronAPI: {
+        httpRequest,
+        abortHttpRequest: vi.fn(),
+      },
+    };
+
+    await executeRequest({ request: req });
+
+    expect(httpRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'QUERY',
+        body: '{"filter":"active"}',
+        headers: {
+          'Content-Type': 'application/query+json',
+          'X-Request-Class': 'query',
+        },
+      }),
+    );
+  });
+
+  it.each(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const)(
+    'continues to send existing %s methods unchanged',
+    async (method) => {
+      const originalFetch = globalThis.fetch;
+      const fetchMock = vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ status: 200, statusText: 'OK', headers: {}, body: '', time: 0, size: 0 }),
+      });
+      globalThis.fetch = fetchMock;
+
+      await executeRequest({ request: { ...baseRequest, method } as any });
+      const callBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(callBody.method).toBe(method);
+
+      globalThis.fetch = originalFetch;
+    },
+  );
 
   it('sends form-data body as serialized entries in Electron mode', async () => {
     const req = {

--- a/test/openapi.test.ts
+++ b/test/openapi.test.ts
@@ -318,3 +318,41 @@ describe('importOpenAPISpec – tag grouping', () => {
     expect(result.folders.some(f => f.name === 'Primary')).toBe(true);
   });
 });
+
+describe('importOpenAPISpec – QUERY method support', () => {
+  it('imports QUERY operations with request body, headers, and query params', () => {
+    const spec = JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'Query API', version: '1' },
+      paths: {
+        '/search': {
+          query: {
+            summary: 'Query search',
+            parameters: [
+              { name: 'filter', in: 'query', required: true },
+              { name: 'X-Query-Token', in: 'header', required: true },
+            ],
+            requestBody: {
+              content: { 'application/json': { schema: { type: 'object' } } },
+            },
+            responses: { '200': { description: 'OK' } },
+          },
+        },
+      },
+    });
+
+    const result = importOpenAPISpec(spec);
+    const request = result.requests[0] ?? result.folders[0].requests[0];
+
+    expect(request.method).toBe('QUERY');
+    expect(request.url).toContain('/search');
+    expect(request.params).toEqual([
+      expect.objectContaining({ key: 'filter', enabled: true }),
+    ]);
+    expect(request.headers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'X-Query-Token', enabled: true }),
+      expect.objectContaining({ key: 'Content-Type', value: 'application/json', enabled: true }),
+    ]));
+    expect(request.body).toEqual({ type: 'json', raw: '{}' });
+  });
+});

--- a/test/persistence.test.ts
+++ b/test/persistence.test.ts
@@ -290,6 +290,40 @@ describe('prepareForWrite', () => {
     expect(() => prepareForWrite(null)).not.toThrow();
     expect(() => prepareForWrite({})).not.toThrow();
   });
+
+  it('preserves QUERY method, headers, and body through history persistence round-trip', () => {
+    const stateWrapper = {
+      state: {
+        history: [{
+          id: 'history-query',
+          request: {
+            id: 'request-query',
+            name: 'Query History',
+            method: 'QUERY',
+            url: 'https://api.example.com/query',
+            headers: [{ id: 'h1', key: 'Content-Type', value: 'application/json', enabled: true }],
+            params: [{ id: 'p1', key: 'filter', value: 'active', enabled: true }],
+            body: { type: 'json', raw: '{"filter":"active"}' },
+            auth: { type: 'none' },
+          },
+          response: { status: 200, statusText: 'OK', headers: {}, body: '{}', time: 1, size: 2 },
+          timestamp: Date.now(),
+        }],
+        environments: [],
+        collections: [],
+      },
+    };
+
+    const { cleanState } = prepareForWrite(stateWrapper);
+    const restored = hydrateAfterRead(cleanState, {}).state.history[0].request;
+
+    expect(restored).toMatchObject({
+      method: 'QUERY',
+      headers: [expect.objectContaining({ key: 'Content-Type', value: 'application/json' })],
+      params: [expect.objectContaining({ key: 'filter', value: 'active' })],
+      body: { type: 'json', raw: '{"filter":"active"}' },
+    });
+  });
 });
 
 // ─── hydrateAfterRead ───────────────────────────────────────────────────────

--- a/test/postman.test.ts
+++ b/test/postman.test.ts
@@ -985,3 +985,51 @@ describe('importPostmanCollection – GH-94 missing optional fields', () => {
     expect(req.body.type).toBe('none');
   });
 });
+
+describe('Postman QUERY method round-trip', () => {
+  it('preserves QUERY method, headers, params, and JSON body through import/export/import', () => {
+    const source = JSON.stringify({
+      info: { name: 'Query Round Trip', schema: '' },
+      item: [{
+        name: 'Query Request',
+        request: {
+          method: 'QUERY',
+          url: {
+            raw: 'https://api.example.com/query',
+            query: [{ key: 'filter', value: 'active', disabled: false }],
+          },
+          header: [
+            { key: 'Content-Type', value: 'application/json', disabled: false },
+            { key: 'X-Query', value: 'enabled', disabled: false },
+          ],
+          body: {
+            mode: 'raw',
+            raw: '{"filter":"active"}',
+            options: { raw: { language: 'json' } },
+          },
+        },
+      }],
+    });
+
+    const imported = importPostmanCollection(source)!;
+    const importedRequest = imported.requests[0];
+    expect(importedRequest.method).toBe('QUERY');
+    expect(importedRequest.body).toEqual({ type: 'json', raw: '{"filter":"active"}' });
+
+    const exported = JSON.parse(exportToPostman(imported));
+    const exportedRequest = exported.item[0].request;
+    expect(exportedRequest.method).toBe('QUERY');
+    expect(exportedRequest.url.query).toEqual([
+      expect.objectContaining({ key: 'filter', value: 'active', disabled: false }),
+    ]);
+    expect(exportedRequest.header).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'Content-Type', value: 'application/json', disabled: false }),
+      expect.objectContaining({ key: 'X-Query', value: 'enabled', disabled: false }),
+    ]));
+    expect(exportedRequest.body).toMatchObject({ mode: 'raw', raw: '{"filter":"active"}' });
+
+    const reimported = importPostmanCollection(JSON.stringify(exported))!;
+    expect(reimported.requests[0].method).toBe('QUERY');
+    expect(reimported.requests[0].body).toEqual({ type: 'json', raw: '{"filter":"active"}' });
+  });
+});

--- a/test/types-index.test.ts
+++ b/test/types-index.test.ts
@@ -27,11 +27,11 @@ import type {
 
 // ─── HttpMethod ───────────────────────────────────────────────────────────────
 
-const HTTP_METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'];
+const HTTP_METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY'];
 
 describe('HttpMethod', () => {
-  it('includes all 7 standard HTTP methods', () => {
-    expect(HTTP_METHODS).toHaveLength(7);
+  it('includes all 8 supported HTTP methods', () => {
+    expect(HTTP_METHODS).toHaveLength(8);
   });
 
   it('includes GET, POST, PUT, PATCH, DELETE', () => {
@@ -45,6 +45,10 @@ describe('HttpMethod', () => {
   it('includes HEAD and OPTIONS', () => {
     expect(HTTP_METHODS).toContain('HEAD');
     expect(HTTP_METHODS).toContain('OPTIONS');
+  });
+
+  it('includes QUERY', () => {
+    expect(HTTP_METHODS).toContain('QUERY');
   });
 });
 

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -279,13 +279,13 @@ describe('requireDirectoryPath', () => {
 
 describe('requireHttpMethod', () => {
   it('accepts all standard HTTP methods (uppercase)', () => {
-    for (const m of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']) {
+    for (const m of ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS', 'QUERY']) {
       expect(requireHttpMethod(m, 'method')).toBe(m);
     }
   });
 
   it('accepts lowercase methods', () => {
-    for (const m of ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']) {
+    for (const m of ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'query']) {
       expect(requireHttpMethod(m, 'method')).toBe(m);
     }
   });


### PR DESCRIPTION
Fixes #98

## Summary
- Adds QUERY as a first-class HTTP method without aliasing it to GET or POST.
- Preserves QUERY through request editing, execution, validation, persistence, history, import/export, and AI integrations.
- Adds regression coverage across the HTTP client, stores, persistence, importers, parsers, validation, and request UI.

## Testing
- Full Vitest suite passed.
- npx tsc --noEmit passed.

## 🤖 AI Review

**Verdict: Comment — follow-up recommended; no blocking core execution or security defect found. Human approval is still required before merge.**

**Source task:** [GH-98](https://github.com/akineralkan/fetchy/issues/98)  
**Reviewed PR:** [#99](https://github.com/akineralkan/fetchy/pull/99)

### Summary
The change consistently adds `QUERY` to the core `HttpMethod` type, request selector, method styling, Electron IPC validator, native Node HTTP execution path, persistence/history flows, supported importer paths, and AI prompt schemas. It does not alias `QUERY` to `GET` or `POST`.

### Findings
1. **P2 — OpenAPI editor preview does not recognize `QUERY`.** The collection importer accepts `query`, but the OpenAPI document preview still uses a hard-coded method set that omits it in [OpenApiEditor.tsx](src/components/openapi/OpenApiEditor.tsx#L370-L375). `METHOD_COLORS` also has no `query` entry in [constants.ts](src/components/openapi/constants.ts#L379-L387). A document containing a QUERY operation would therefore be omitted from the preview, or use fallback styling if the filter is extended independently. Add `query` to both locations and cover the preview path with a regression test if OpenAPI editor support is intended as part of first-class method support.
2. **Test-coverage gap (non-blocking) — no end-to-end Electron handler test.** The new execution tests verify the renderer payload sent to a mocked `electronAPI.httpRequest`, while validator tests exercise `requireHttpMethod` separately. A local HTTP-server test through the registered IPC handler would verify the complete allowlist → `http.request({ method: 'QUERY' })` path and catch wiring regressions.
3. **UX observation (non-blocking) — method filters remain curated.** Collection/history filter menus in [Sidebar.tsx](src/components/Sidebar.tsx#L901-L901) and [Sidebar.tsx](src/components/Sidebar.tsx#L1015-L1015) do not offer `QUERY` (and pre-existing `HEAD`/`OPTIONS` are also absent). Saved QUERY requests remain viewable and executable, but cannot be selected through those method filters. This is outside the explicit issue acceptance criteria, but should be considered for complete first-class discoverability.

### Security review
- The Electron allowlist adds only the exact `QUERY` and `query` tokens; it does not introduce arbitrary-method or shell-command injection.
- Existing URL validation remains in place, and the method is passed directly to Node's HTTP client rather than interpreted by a shell.
- No new SSRF widening was introduced by this patch; the existing proxy/TLS behavior is unchanged.
- No secret exposure or new unsafe input handling was identified in the changed code.

### Validation
- `npx tsc --noEmit`: passed.
- `npm test`: 99/99 files and 2402/2402 tests passed.
- `npm run lint`: the repository's existing 1 error and 79 warnings remain; the error is in unchanged [OpenApiEditor.test.tsx](test/components/openapi/OpenApiEditor.test.tsx#L68-L68), with no new lint error identified in the changed files.

**Recommendation:** retain the current implementation for the core QUERY execution path, and address the OpenAPI preview omission before calling QUERY support complete across all OpenAPI UI surfaces.

**AI review source:** Pantheon task `GH-98` / issue https://github.com/akineralkan/fetchy/issues/98.